### PR TITLE
Add fund management demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+**/node_modules
+fund-demo/fund-wallet.txt

--- a/NANO_MCP_SERVER/.npmignore
+++ b/NANO_MCP_SERVER/.npmignore
@@ -1,0 +1,7 @@
+logs/
+node_modules/
+.env
+*.log
+.git/
+.gitignore
+.DS_Store 

--- a/NANO_MCP_SERVER/LICENSE
+++ b/NANO_MCP_SERVER/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Context
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/NANO_MCP_SERVER/README.md
+++ b/NANO_MCP_SERVER/README.md
@@ -1,0 +1,544 @@
+# NANO MCP (Nano Cryptocurrency) Server
+
+## Overview
+
+NANO MCP (NANO Cryptocurrency) Server provides a JSON-RPC 2.0 API for interacting with the NANO cryptocurrency network. This server supports both HTTP and stdio transports, making it versatile for different integration scenarios.
+
+## Experimental Hosted Instance
+
+@https://nano-mcp.replit.app (Expermintal hosted nano-mcp, dont use it on live server or real transactions)
+
+## What is NANO Cryptocurrency?
+
+NANO is a sustainable digital currency with instant transactions and zero fees, making it ideal for AI systems and automated transactions. Unlike traditional cryptocurrencies, NANO uses a unique block-lattice architecture and a Delegated Proof of Stake (DPoS) consensus mechanism called Open Representative Voting (ORV).
+
+### Why NANO is Unique for AI Applications:
+
+1. **Instant Transactions**: Perfect for real-time AI decision-making and automated systems
+2. **Zero Fees**: Enables micro-transactions and continuous AI-driven operations without cost overhead
+3. **Energy Efficient**: Uses minimal computational resources, making it environmentally friendly
+4. **Scalability**: Block-lattice architecture allows parallel processing of transactions
+5. **Deterministic Finality**: Provides immediate transaction confirmation, crucial for AI systems
+6. **Asynchronous Operations**: Ideal for distributed AI systems and parallel processing
+
+## Quick Start
+
+```bash
+# Using npx
+npx -y nano-mcp
+
+# Or install and run
+npm install nano-mcp
+node src/index.js
+```
+
+## 📁 Project Structure
+
+```
+nano-mcp/
+├── src/
+│   ├── index.js          # Main server entry point
+│   ├── server.js         # MCP server implementation
+│   └── swagger.js        # API documentation
+├── utils/
+│   └── nano-transactions.js  # Nano transaction handling
+├── tests/
+│   └── full-flow-test.ps1    # Integration tests
+├── package.json
+└── README.md
+```
+
+## 🚀 Prerequisites
+
+- Node.js 16+ (as specified in package.json)
+- Express.js for HTTP server
+- Nano cryptocurrency libraries:
+  - nanocurrency
+  - nanocurrency-web
+- Additional dependencies:
+  - body-parser
+  - swagger-ui-express
+  - swagger-jsdoc
+  - ajv (for schema validation)
+
+## JSON-RPC API Reference
+
+### Available Methods
+
+1. `initialize` - Get server capabilities
+2. `generateWallet` - Create new NANO wallet
+3. `getBalance` - Check account balance
+4. `initializeAccount` - Initialize account for transactions
+5. `sendTransaction` - Send NANO to another address
+6. `receiveAllPending` - Process pending receive blocks
+7. `getAccountInfo` - Get detailed account information
+8. `getPendingBlocks` - Check pending transactions
+
+### Method Examples
+
+#### Initialize
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "params": {},
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "version": "1.0.0",
+        "capabilities": {
+            "methods": [
+                "initialize",
+                "generateWallet",
+                "getBalance",
+                "initializeAccount",
+                "sendTransaction",
+                "receiveAllPending",
+                "getAccountInfo",
+                "getPendingBlocks"
+            ]
+        }
+    },
+    "id": 1
+}
+```
+
+#### Generate Wallet
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "generateWallet",
+    "params": {},
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf",
+        "privateKey": "4bc2e9c2df4be93e5cbeb41b52c2fc9efc1b4c0e67951fc6c5098c117913d25a",
+        "publicKey": "3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+    },
+    "id": 1
+}
+```
+
+#### Get Balance
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "getBalance",
+    "params": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+    },
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "balance": "1000000000000000000000000",
+        "pending": "0"
+    },
+    "id": 1
+}
+```
+
+#### Initialize Account
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "initializeAccount",
+    "params": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf",
+        "privateKey": "4bc2e9c2df4be93e5cbeb41b52c2fc9efc1b4c0e67951fc6c5098c117913d25a"
+    },
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "initialized": true,
+        "representative": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+    },
+    "id": 1
+}
+```
+
+#### Send Transaction
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "sendTransaction",
+    "params": {
+        "fromAddress": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf",
+        "toAddress": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+        "amountRaw": "1000000000000000000000000",
+        "privateKey": "4bc2e9c2df4be93e5cbeb41b52c2fc9efc1b4c0e67951fc6c5098c117913d25a"
+    },
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "success": true,
+        "hash": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+        "amount": "1000000000000000000000000",
+        "balance": "0"
+    },
+    "id": 1
+}
+```
+
+#### Receive All Pending
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "receiveAllPending",
+    "params": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf",
+        "privateKey": "4bc2e9c2df4be93e5cbeb41b52c2fc9efc1b4c0e67951fc6c5098c117913d25a"
+    },
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "received": [
+            {
+                "hash": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+                "amount": "1000000000000000000000000",
+                "source": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est"
+            }
+        ]
+    },
+    "id": 1
+}
+```
+
+#### Get Account Info
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "getAccountInfo",
+    "params": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+    },
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "frontier": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+        "open_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+        "representative_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+        "balance": "1000000000000000000000000",
+        "modified_timestamp": "1634567890",
+        "block_count": "1",
+        "representative": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf",
+        "weight": "0",
+        "pending": "0"
+    },
+    "id": 1
+}
+```
+
+#### Get Pending Blocks
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "method": "getPendingBlocks",
+    "params": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+    },
+    "id": 1
+}
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "blocks": {
+            "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948": {
+                "amount": "1000000000000000000000000",
+                "source": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est"
+            }
+        }
+    },
+    "id": 1
+}
+```
+
+## Configuration
+
+Environment variables:
+```bash
+NANO_RPC_URL=https://rpc.nano.to  # NANO node RPC URL
+NANO_RPC_KEY=your-key-here        # API key for authenticated nodes
+MCP_PORT=8080          # HTTP server port
+MCP_TRANSPORT=http     # Transport type (http/stdio)
+NANO_REPRESENTATIVE   # Default representative
+```
+
+## Transport Options
+
+### 1. HTTP Transport (default)
+- REST API on port 8080
+- JSON-RPC 2.0 protocol
+- Swagger docs at /api-docs
+- CORS enabled for all origins
+- Content-Type: application/json
+
+### 2. stdio Transport
+- Direct process communication
+- Line-delimited JSON
+- Responses written to stdout
+- Server messages written to stderr
+
+## Integration Examples
+
+### Node.js
+```javascript
+const axios = require('axios');
+
+async function sendTransaction(fromAddress, toAddress, amount, privateKey) {
+    const response = await axios.post('http://localhost:8080', {
+        jsonrpc: "2.0",
+        method: "sendTransaction",
+        params: {
+            fromAddress,
+            toAddress,
+            amountRaw: amount,
+            privateKey
+        },
+        id: 1
+    });
+    return response.data;
+}
+```
+
+### Python
+```python
+import requests
+
+def send_transaction(from_address, to_address, amount, private_key):
+    response = requests.post('http://localhost:8080', json={
+        "jsonrpc": "2.0",
+        "method": "sendTransaction",
+        "params": {
+            "fromAddress": from_address,
+            "toAddress": to_address,
+            "amountRaw": amount,
+            "privateKey": private_key
+        },
+        "id": 1
+    })
+    return response.json()
+```
+
+## Error Handling
+
+### Error Codes
+| Code    | Message           | Description                                     |
+|---------|------------------|-------------------------------------------------|
+| -32600  | Invalid Request  | The JSON sent is not a valid Request object     |
+| -32601  | Method not found | The method does not exist / is not available    |
+| -32602  | Invalid params   | Invalid method parameters                       |
+| -32603  | Internal error   | Internal JSON-RPC error                         |
+| -32000  | Server error     | Generic server-side error                       |
+
+## Security Considerations
+
+1. Private Key Handling
+   - Never store private keys in plain text
+   - Use secure environment variables
+   - Implement proper key rotation
+
+2. RPC Node Security
+   - Use authenticated RPC nodes
+   - Set `NANO_RPC_KEY` for protected endpoints
+   - Monitor for suspicious activity
+
+3. Rate Limiting
+   - Implement appropriate rate limits
+   - Monitor for abuse
+   - Use proper error responses
+
+## Performance Optimization
+
+1. Connection Pooling
+   - Reuse HTTP connections
+   - Maintain persistent WebSocket connections
+   - Pool RPC requests
+
+2. Caching
+   - Cache account information
+   - Cache block data
+   - Implement proper cache invalidation
+
+## TypeScript Type Definitions
+
+```typescript
+/**
+ * NANO address format with nano_ prefix
+ * @example "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+ */
+type NanoAddress = string;
+
+/**
+ * 64-character hexadecimal private key
+ * @example "4bc2e9c2df4be93e5cbeb41b52c2fc9efc1b4c0e67951fc6c5098c117913d25a"
+ */
+type PrivateKey = string;
+
+/**
+ * Raw amount in string format to handle large numbers
+ * @example "1000000000000000000000000"
+ */
+type RawAmount = string;
+
+/**
+ * 64-character hexadecimal block hash
+ * @example "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
+ */
+type BlockHash = string;
+
+/**
+ * Standard JSON-RPC 2.0 request format
+ */
+interface JsonRpcRequest<T> {
+    jsonrpc: "2.0";
+    method: string;
+    params: T;
+    id: number;
+}
+
+/**
+ * Standard JSON-RPC 2.0 success response format
+ */
+interface JsonRpcResponse<T> {
+    jsonrpc: "2.0";
+    result: T;
+    id: number;
+}
+
+/**
+ * Standard JSON-RPC 2.0 error response format
+ */
+interface JsonRpcError {
+    jsonrpc: "2.0";
+    error: {
+        code: number;
+        message: string;
+        data?: any;
+    };
+    id: number | null;
+}
+
+/**
+ * Response from generateWallet method
+ */
+interface WalletResponse {
+    /** The public address starting with nano_ */
+    address: NanoAddress;
+    /** The private key for the wallet */
+    privateKey: PrivateKey;
+    /** The public key portion of the address */
+    publicKey: string;
+}
+
+/**
+ * Response from getBalance method
+ */
+interface BalanceResponse {
+    /** Current confirmed balance in raw units */
+    balance: RawAmount;
+    /** Sum of pending incoming transactions */
+    pending: RawAmount;
+}
+
+/**
+ * Information about a pending block
+ */
+interface PendingBlock {
+    /** Amount being transferred in raw units */
+    amount: RawAmount;
+    /** Address that sent the transaction */
+    source: NanoAddress;
+}
+
+/**
+ * Response from a send transaction
+ */
+interface TransactionResponse {
+    /** Whether the transaction was successful */
+    success: boolean;
+    /** Hash of the transaction block */
+    hash: BlockHash;
+    /** Amount that was sent in raw units */
+    amount: RawAmount;
+    /** New balance after the transaction */
+    balance: RawAmount;
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. Connection Refused
+   - Check if server is running
+   - Verify correct port
+   - Check firewall settings
+
+2. Invalid JSON-RPC
+   - Validate request format
+   - Check method name
+   - Verify parameter types
+
+3. Transaction Failures
+   - Check account balance
+   - Verify private key
+   - Ensure sufficient funds
+
+4. Port Already in Use
+   - Stop any existing MCP server instances
+   - Change port using MCP_PORT environment variable
+   - Check for other services using port 8080
+
+5. RPC Node Issues
+   - Verify NANO_RPC_URL is accessible
+   - Check NANO_RPC_KEY is valid
+   - Monitor RPC node status
+
+## Support
+
+For issues and feature requests, please:
+1. Check the documentation
+2. Search existing issues
+3. Create a new issue with:
+   - Environment details
+   - Steps to reproduce
+   - Expected vs actual behavior 

--- a/NANO_MCP_SERVER/docs/DOCUMENTATION_PLAN.md
+++ b/NANO_MCP_SERVER/docs/DOCUMENTATION_PLAN.md
@@ -1,0 +1,142 @@
+# MCP Documentation Enhancement Plan
+
+## Phase 1: Code-Level Documentation
+
+### 1. Function/Method Documentation
+- [ ] Add JSDoc comments to all functions in `src/` directory
+  ```typescript
+  /**
+   * Handles incoming JSON-RPC requests and routes them to appropriate handlers
+   * @param {Object} request - The JSON-RPC request object
+   * @param {string} request.method - The method name to execute
+   * @param {Object} request.params - Method parameters
+   * @param {number} request.id - Request identifier
+   * @returns {Promise<Object>} JSON-RPC response object
+   * @throws {Error} When method is not found or invalid parameters
+   */
+  ```
+- [ ] Document complex algorithms with step-by-step explanations
+- [ ] Add TypeScript type definitions for better IDE support
+
+### 2. Class/Interface Documentation
+- [ ] Document all TypeScript interfaces with detailed descriptions
+- [ ] Add MCP protocol compliance notes to relevant classes
+- [ ] Create class relationship diagrams using Mermaid
+- [ ] Document data structures and their purposes
+
+### 3. Business Logic Documentation
+- [ ] Add decision documentation for:
+  - Transport selection logic
+  - Error handling strategies
+  - Security measures
+  - Performance optimizations
+- [ ] Document edge cases and their handling
+- [ ] Add protocol-specific implementation notes
+
+### 4. Configuration Documentation
+- [ ] Document all environment variables:
+  ```env
+  MCP_PORT=8080          # Port for HTTP transport (default: 8080)
+  MCP_TRANSPORT=http     # Transport type: 'http' or 'stdio'
+  NANO_RPC_URL          # NANO node RPC endpoint
+  NANO_RPC_KEY          # API key for NANO node (if required)
+  NANO_REPRESENTATIVE   # Default representative for new accounts
+  ```
+- [ ] List all dependencies and their purposes
+- [ ] Document performance considerations and recommendations
+
+## Phase 2: API Documentation
+
+### 1. Tool Definitions
+- [ ] Create detailed parameter schemas for each tool
+- [ ] Add input/output examples
+- [ ] Document error scenarios and responses
+- [ ] Provide usage examples
+
+### 2. MCP Protocol Documentation
+- [ ] Document protocol version support
+- [ ] List and explain available capabilities
+- [ ] Document resource management
+- [ ] Explain connection lifecycle
+
+### 3. Integration Guide
+- [ ] Add client configuration examples for different environments
+- [ ] Document authentication mechanisms
+- [ ] Add rate limiting information
+- [ ] Create troubleshooting guide
+
+### 4. API Reference
+- [ ] Document all endpoints with:
+  - Method description
+  - Request/response schemas
+  - Error codes
+  - Examples
+- [ ] Add performance characteristics
+- [ ] Document rate limits and quotas
+
+## Implementation Timeline
+
+### Week 1: Code-Level Documentation
+- Day 1-2: Function/Method documentation
+- Day 3-4: Class/Interface documentation
+- Day 5: Business logic documentation
+
+### Week 2: Configuration and API Documentation
+- Day 1-2: Configuration documentation
+- Day 3-5: API reference documentation
+
+### Week 3: Integration and Protocol Documentation
+- Day 1-2: Tool definitions
+- Day 3-4: MCP protocol documentation
+- Day 5: Integration guide
+
+## Documentation Standards
+
+### 1. JSDoc Standards
+```typescript
+/**
+ * @description Clear description of the function/method
+ * @param {type} name - Parameter description
+ * @returns {type} Description of return value
+ * @throws {ErrorType} Description of when this error occurs
+ * @example
+ * // Usage example
+ * const result = await functionName(params);
+ */
+```
+
+### 2. Markdown Standards
+- Use consistent headers (H1 for file titles, H2 for major sections)
+- Include code examples in appropriate language blocks
+- Use tables for parameter/response documentation
+- Include links to related documentation
+
+### 3. API Documentation Standards
+- Use OpenAPI/Swagger format
+- Include request/response examples
+- Document all possible error responses
+- Provide curl examples
+
+## Validation Process
+
+1. Documentation Review
+   - Peer review of all documentation changes
+   - Validation of examples and code snippets
+   - Spell check and grammar review
+
+2. Technical Validation
+   - Test all code examples
+   - Verify all configuration options
+   - Validate API documentation against implementation
+
+3. User Testing
+   - Internal developer testing
+   - External user feedback
+   - Integration testing with example code
+
+## Next Steps
+
+1. Create documentation templates
+2. Set up automated documentation generation
+3. Implement documentation CI/CD pipeline
+4. Create documentation review process 

--- a/NANO_MCP_SERVER/docs/api/README.md
+++ b/NANO_MCP_SERVER/docs/api/README.md
@@ -1,0 +1,239 @@
+# MCP API Documentation
+
+## Overview
+
+MCP (NANO Cryptocurrency) Server provides a JSON-RPC 2.0 API for interacting with the NANO cryptocurrency network. This server supports both HTTP and stdio transports, making it versatile for different integration scenarios.
+
+## Quick Start
+
+```bash
+# Start the server with HTTP transport (default)
+node src/index.js
+
+# Start with stdio transport
+MCP_TRANSPORT=stdio node src/index.js
+```
+
+## Available Methods
+
+### initialize
+
+Initializes the connection and returns server capabilities.
+
+**Request:**
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "params": {},
+    "id": 1
+}
+```
+
+**Response:**
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "version": "1.0.0",
+        "capabilities": {
+            "methods": [
+                "initialize",
+                "generateWallet",
+                "getBalance",
+                "initializeAccount",
+                "sendTransaction",
+                "receiveAllPending",
+                "getAccountInfo",
+                "getPendingBlocks"
+            ]
+        }
+    },
+    "id": 1
+}
+```
+
+### generateWallet
+
+Generates a new NANO wallet with address and private key.
+
+**Request:**
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "generateWallet",
+    "params": {},
+    "id": 1
+}
+```
+
+**Response:**
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf",
+        "privateKey": "4bc2e9c2df4be93e5cbeb41b52c2fc9efc1b4c0e67951fc6c5098c117913d25a",
+        "publicKey": "3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+    },
+    "id": 1
+}
+```
+
+### getBalance
+
+Retrieves the balance for a NANO address.
+
+**Request:**
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "getBalance",
+    "params": {
+        "address": "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+    },
+    "id": 1
+}
+```
+
+**Response:**
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "balance": "1000000000000000000000000",
+        "pending": "0"
+    },
+    "id": 1
+}
+```
+
+## Error Codes
+
+| Code    | Message           | Description                                     |
+|---------|------------------|-------------------------------------------------|
+| -32600  | Invalid Request  | The JSON sent is not a valid Request object     |
+| -32601  | Method not found | The method does not exist / is not available    |
+| -32602  | Invalid params   | Invalid method parameters                       |
+| -32603  | Internal error   | Internal JSON-RPC error                         |
+| -32000  | Server error     | Generic server-side error                       |
+
+## Transport Options
+
+### HTTP Transport
+
+The HTTP transport runs on port 8080 by default and accepts POST requests with JSON-RPC 2.0 formatted bodies.
+
+**Configuration:**
+- Port: Set via `MCP_PORT` environment variable (default: 8080)
+- CORS: Enabled for all origins
+- Content-Type: application/json
+
+### stdio Transport
+
+The stdio transport allows for direct process communication using stdin/stdout.
+
+**Configuration:**
+- Set `MCP_TRANSPORT=stdio` environment variable
+- Each request/response must be on a single line
+- Responses are written to stdout
+- Server messages are written to stderr
+
+## Security Considerations
+
+1. Private Key Handling
+   - Never store private keys in plain text
+   - Use secure environment variables
+   - Implement proper key rotation
+
+2. RPC Node Security
+   - Use authenticated RPC nodes
+   - Set `NANO_RPC_KEY` for protected endpoints
+   - Monitor for suspicious activity
+
+3. Rate Limiting
+   - Implement appropriate rate limits
+   - Monitor for abuse
+   - Use proper error responses
+
+## Performance Optimization
+
+1. Connection Pooling
+   - Reuse HTTP connections
+   - Maintain persistent WebSocket connections
+   - Pool RPC requests
+
+2. Caching
+   - Cache account information
+   - Cache block data
+   - Implement proper cache invalidation
+
+## Integration Examples
+
+### Node.js
+```javascript
+const axios = require('axios');
+
+async function sendTransaction(fromAddress, toAddress, amount, privateKey) {
+    const response = await axios.post('http://localhost:8080', {
+        jsonrpc: "2.0",
+        method: "sendTransaction",
+        params: {
+            fromAddress,
+            toAddress,
+            amountRaw: amount,
+            privateKey
+        },
+        id: 1
+    });
+    return response.data;
+}
+```
+
+### Python
+```python
+import requests
+
+def send_transaction(from_address, to_address, amount, private_key):
+    response = requests.post('http://localhost:8080', json={
+        "jsonrpc": "2.0",
+        "method": "sendTransaction",
+        "params": {
+            "fromAddress": from_address,
+            "toAddress": to_address,
+            "amountRaw": amount,
+            "privateKey": private_key
+        },
+        "id": 1
+    })
+    return response.json()
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. Connection Refused
+   - Check if server is running
+   - Verify correct port
+   - Check firewall settings
+
+2. Invalid JSON-RPC
+   - Validate request format
+   - Check method name
+   - Verify parameter types
+
+3. Transaction Failures
+   - Check account balance
+   - Verify private key
+   - Ensure sufficient PoW
+
+## Support
+
+For issues and feature requests, please:
+1. Check the documentation
+2. Search existing issues
+3. Create a new issue with:
+   - Environment details
+   - Steps to reproduce
+   - Expected vs actual behavior 

--- a/NANO_MCP_SERVER/docs/types/README.md
+++ b/NANO_MCP_SERVER/docs/types/README.md
@@ -1,0 +1,238 @@
+# MCP TypeScript Type Definitions
+
+## Common Types
+
+```typescript
+/**
+ * NANO address format with nano_ prefix
+ * @example "nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf"
+ */
+type NanoAddress = string;
+
+/**
+ * 64-character hexadecimal private key
+ * @example "4bc2e9c2df4be93e5cbeb41b52c2fc9efc1b4c0e67951fc6c5098c117913d25a"
+ */
+type PrivateKey = string;
+
+/**
+ * Raw amount in string format to handle large numbers
+ * @example "1000000000000000000000000"
+ */
+type RawAmount = string;
+
+/**
+ * 64-character hexadecimal block hash
+ * @example "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
+ */
+type BlockHash = string;
+```
+
+## JSON-RPC Types
+
+```typescript
+/**
+ * Standard JSON-RPC 2.0 request format
+ */
+interface JsonRpcRequest<T> {
+    jsonrpc: "2.0";
+    method: string;
+    params: T;
+    id: number;
+}
+
+/**
+ * Standard JSON-RPC 2.0 success response format
+ */
+interface JsonRpcResponse<T> {
+    jsonrpc: "2.0";
+    result: T;
+    id: number;
+}
+
+/**
+ * Standard JSON-RPC 2.0 error response format
+ */
+interface JsonRpcError {
+    jsonrpc: "2.0";
+    error: {
+        code: number;
+        message: string;
+        data?: any;
+    };
+    id: number | null;
+}
+```
+
+## Method-Specific Types
+
+### Wallet Operations
+
+```typescript
+/**
+ * Response from generateWallet method
+ */
+interface WalletResponse {
+    /** The public address starting with nano_ */
+    address: NanoAddress;
+    /** The private key for the wallet */
+    privateKey: PrivateKey;
+    /** The public key portion of the address */
+    publicKey: string;
+}
+
+/**
+ * Response from getBalance method
+ */
+interface BalanceResponse {
+    /** Current confirmed balance in raw units */
+    balance: RawAmount;
+    /** Sum of pending incoming transactions */
+    pending: RawAmount;
+}
+
+/**
+ * Detailed account information response
+ */
+interface AccountInfoResponse {
+    /** Hash of the latest block in the account chain */
+    frontier: BlockHash;
+    /** Hash of the first block in the account chain */
+    open_block: BlockHash;
+    /** Hash of the block setting the current representative */
+    representative_block: BlockHash;
+    /** Current account balance in raw units */
+    balance: RawAmount;
+    /** Last modified timestamp */
+    modified_timestamp: string;
+    /** Total number of blocks in the account chain */
+    block_count: string;
+    /** Current representative address */
+    representative: NanoAddress;
+    /** Voting weight of the account */
+    weight: string;
+    /** Sum of pending incoming transactions */
+    pending: RawAmount;
+}
+```
+
+### Transaction Operations
+
+```typescript
+/**
+ * Information about a pending block
+ */
+interface PendingBlock {
+    /** Amount being transferred in raw units */
+    amount: RawAmount;
+    /** Address that sent the transaction */
+    source: NanoAddress;
+}
+
+/**
+ * Response containing all pending blocks
+ */
+interface PendingBlocksResponse {
+    /** Map of block hashes to pending block information */
+    blocks: {
+        [hash: BlockHash]: PendingBlock;
+    };
+}
+
+/**
+ * Response from a send transaction
+ */
+interface TransactionResponse {
+    /** Whether the transaction was successful */
+    success: boolean;
+    /** Hash of the transaction block */
+    hash: BlockHash;
+    /** Amount that was sent in raw units */
+    amount: RawAmount;
+    /** New balance after the transaction */
+    balance: RawAmount;
+}
+
+/**
+ * Response from receiving pending transactions
+ */
+interface ReceiveResponse {
+    /** Array of received transactions */
+    received: Array<{
+        /** Hash of the received block */
+        hash: BlockHash;
+        /** Amount received in raw units */
+        amount: RawAmount;
+        /** Address that sent the transaction */
+        source: NanoAddress;
+    }>;
+}
+```
+
+## Usage Examples
+
+### Sending a Transaction
+
+```typescript
+async function sendNano(
+    fromAddress: NanoAddress,
+    toAddress: NanoAddress,
+    amount: RawAmount,
+    privateKey: PrivateKey
+): Promise<TransactionResponse> {
+    const request: JsonRpcRequest<{
+        fromAddress: NanoAddress;
+        toAddress: NanoAddress;
+        amountRaw: RawAmount;
+        privateKey: PrivateKey;
+    }> = {
+        jsonrpc: "2.0",
+        method: "sendTransaction",
+        params: {
+            fromAddress,
+            toAddress,
+            amountRaw: amount,
+            privateKey
+        },
+        id: 1
+    };
+
+    // Make the request to the MCP server
+    const response = await fetch("http://localhost:8080", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(request)
+    });
+
+    return (await response.json()).result;
+}
+```
+
+### Checking Balance
+
+```typescript
+async function checkBalance(address: NanoAddress): Promise<BalanceResponse> {
+    const request: JsonRpcRequest<{
+        address: NanoAddress;
+    }> = {
+        jsonrpc: "2.0",
+        method: "getBalance",
+        params: {
+            address
+        },
+        id: 1
+    };
+
+    const response = await fetch("http://localhost:8080", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(request)
+    });
+
+    return (await response.json()).result;
+}
+``` 

--- a/NANO_MCP_SERVER/package-lock.json
+++ b/NANO_MCP_SERVER/package-lock.json
@@ -1,0 +1,1328 @@
+{
+  "name": "nano-mcp",
+  "version": "1.2.28",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nano-mcp",
+      "version": "1.2.28",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "body-parser": "^2.2.0",
+        "express": "^5.1.0",
+        "nanocurrency": "^1.12.0",
+        "nanocurrency-web": "^1.4.3",
+        "node-fetch": "^2.7.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
+      },
+      "bin": {
+        "nano-mcp": "src/index.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
+      "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA==",
+      "deprecated": "Custom ALPHABET bug fixed in v7.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/byte-base64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/byte-base64/-/byte-base64-1.1.0.tgz",
+      "integrity": "sha512-56cXelkJrVMdCY9V/3RfDxTh4VfMFCQ5km7B7GkIGfo4bcPL9aACyJLB0Ms3Ezu5rsHmLB2suis96z4fLM03DA==",
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha512-W93aKztssqf29OvUlqfikzGyYbD1rpkXvGP9IQ1JchLY3bxaLXZSWYbwrtib2vk8DobrDzX7PIXcDWHp0B6Ymw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nano-base32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nano-base32/-/nano-base32-1.0.1.tgz",
+      "integrity": "sha512-sxEtoTqAPdjWVGv71Q17koMFGsOMSiHsIFEvzOM7cNp8BXB4AnEwmDabm5dorusJf/v1z7QxaZYxUorU9RKaAw==",
+      "license": "MIT"
+    },
+    "node_modules/nanocurrency": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/nanocurrency/-/nanocurrency-1.12.0.tgz",
+      "integrity": "sha512-dCkgYnbZjvM9/BR1YJ2c+CzZUjd2W3/9EaaFg5Gq4E2KfD3YgAdAKErDhkYGItlDvxo5Zz7+T8K93aADBSAdew==",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "bignumber.js": "^6.0.0",
+        "blakejs": "^1.1.0",
+        "nano-base32": "^1.0.0"
+      }
+    },
+    "node_modules/nanocurrency-web": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nanocurrency-web/-/nanocurrency-web-1.4.3.tgz",
+      "integrity": "sha512-okmnHweUjZq3j/f2W5qYl4Ir4GAhGyL2BJJQEeZvo+qIHkdI4d7RbJDQKNK1VXAmdFZ4mElOPLGUBv6i+x+XRg==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "9.0.2",
+        "blakejs": "1.2.1",
+        "byte-base64": "1.1.0",
+        "crypto-js": "3.1.9-1"
+      }
+    },
+    "node_modules/nanocurrency-web/node_modules/bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.24.1.tgz",
+      "integrity": "sha512-ITeWc7CCAfK53u8jnV39UNqStQZjSt+bVYtJHsOEL3vVj/WV9/8HmsF8Ej4oD8r+Xk1HpWyeW/t59r1QNeAcUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    }
+  }
+}

--- a/NANO_MCP_SERVER/package.json
+++ b/NANO_MCP_SERVER/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "nano-mcp",
+  "version": "1.2.28",
+  "description": "NANO MCP (Nano Cryptocurrency) Server for AI Assistants - A JSON-RPC 2.0 API server for Nano cryptocurrency operations",
+  "main": "src/index.js",
+  "bin": {
+    "nano-mcp": "src/index.js"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "nano",
+    "cryptocurrency",
+    "nano-mcp",
+    "server",
+    "json-rpc",
+    "api",
+    "blockchain",
+    "wallet"
+  ],
+  "author": {
+    "name": "NANO MCP Team",
+    "url": "https://github.com/dhyabi2/nano-mcp"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "body-parser": "^2.2.0",
+    "express": "^5.1.0",
+    "nanocurrency": "^1.12.0",
+    "nanocurrency-web": "^1.4.3",
+    "node-fetch": "^2.7.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dhyabi2/nano-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/dhyabi2/nano-mcp/issues"
+  },
+  "homepage": "https://github.com/dhyabi2/nano-mcp#readme",
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "files": [
+    "src/",
+    "utils/",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/NANO_MCP_SERVER/src/index.js
+++ b/NANO_MCP_SERVER/src/index.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const { NanoMCPServer } = require('./server');
+const { StdioTransport } = require('./stdio-transport');
+
+// Default configuration
+const config = {
+    port: process.env.MCP_PORT || 8080,
+    apiUrl: process.env.NANO_RPC_URL || 'https://rpc.nano.to',
+    rpcKey: process.env.NANO_RPC_KEY || 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23',
+    defaultRepresentative: process.env.NANO_REPRESENTATIVE || 'nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf',
+    transport: process.env.MCP_TRANSPORT || 'http' // 'http' or 'stdio'
+};
+
+// Create and start server
+const server = new NanoMCPServer(config);
+
+if (config.transport === 'stdio') {
+    const stdioTransport = new StdioTransport(server);
+    stdioTransport.start();
+    console.error('NANO MCP Server running in stdio mode');
+} else {
+    server.startHttp();
+}
+
+// Handle process termination
+process.on('SIGINT', () => {
+    console.error('\nShutting down NANO MCP Server...');
+    process.exit(0);
+}); 

--- a/NANO_MCP_SERVER/src/key-manager.js
+++ b/NANO_MCP_SERVER/src/key-manager.js
@@ -1,0 +1,18 @@
+const { NanoTransactions } = require('../utils/nano-transactions');
+
+class KeyManager {
+    constructor(config) {
+        this.nanoTransactions = new NanoTransactions({}, config);
+    }
+
+    async generateKeyPair() {
+        const wallet = await this.nanoTransactions.generateWallet();
+        return {
+            publicKey: wallet.publicKey,
+            privateKey: wallet.privateKey,
+            address: wallet.address
+        };
+    }
+}
+
+module.exports = { KeyManager }; 

--- a/NANO_MCP_SERVER/src/server.js
+++ b/NANO_MCP_SERVER/src/server.js
@@ -1,0 +1,232 @@
+const http = require('http');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpecs = require('./swagger');
+const { NanoTransactions } = require('../utils/nano-transactions');
+const { SchemaValidator } = require('../utils/schema-validator');
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const DEFAULT_PORT = 8080;
+
+// CORS headers configuration
+const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Max-Age': '86400' // 24 hours
+};
+
+/**
+ * @swagger
+ * /api-docs:
+ *   get:
+ *     summary: Get API documentation
+ *     description: Returns the Swagger UI documentation
+ *     responses:
+ *       200:
+ *         description: API documentation
+ */
+/**
+ * NANO MCP (NANO Cryptocurrency) Server implementation
+ * Provides a JSON-RPC 2.0 interface for interacting with the NANO network
+ * Supports both HTTP and stdio transports
+ */
+class NanoMCPServer {
+    /**
+     * Creates a new NANO MCP Server instance
+     * @param {Object} config - Server configuration
+     * @param {number} [config.port=8080] - HTTP server port
+     * @param {string} [config.apiUrl='https://rpc.nano.to'] - NANO RPC node URL
+     * @param {string} [config.rpcKey] - API key for authenticated RPC nodes
+     * @param {string} [config.defaultRepresentative] - Default representative for new accounts
+     */
+    constructor(config = {}) {
+        this.config = {
+            port: process.env.MCP_PORT || 8080,
+            apiUrl: process.env.NANO_RPC_URL || 'https://rpc.nano.to',
+            rpcKey: process.env.NANO_RPC_KEY || 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23',
+            defaultRepresentative: process.env.NANO_REPRESENTATIVE || 'nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf',
+            ...config
+        };
+        this.nanoTransactions = new NanoTransactions(this.config);
+        this.schemaValidator = SchemaValidator.getInstance();
+    }
+
+    /**
+     * Handles incoming JSON-RPC requests
+     * @param {Object} request - JSON-RPC request object
+     * @param {string} request.method - Method name to execute
+     * @param {Object} request.params - Method parameters
+     * @param {number} request.id - Request identifier
+     * @returns {Promise<Object>} JSON-RPC response object
+     * @throws {Error} When method is not found or parameters are invalid
+     */
+    async handleRequest(request) {
+        try {
+            const { method, params, id } = request;
+            let result;
+
+            switch (method) {
+                case 'initialize':
+                    result = {
+                        version: "1.0.0",
+                        capabilities: {
+                            methods: [
+                                "initialize",
+                                "generateWallet",
+                                "getBalance",
+                                "initializeAccount",
+                                "sendTransaction",
+                                "receiveAllPending",
+                                "getAccountInfo",
+                                "getPendingBlocks"
+                            ]
+                        }
+                    };
+                    break;
+                case 'generateWallet':
+                    result = await this.nanoTransactions.generateWallet();
+                    break;
+                case 'getBalance':
+                    this.schemaValidator.validate(params, {
+                        type: 'object',
+                        required: ['address'],
+                        properties: {
+                            address: { type: 'string' }
+                        }
+                    });
+                    const balanceInfo = await this.nanoTransactions.getAccountInfo(params.address);
+                    result = {
+                        balance: balanceInfo.balance || '0',
+                        pending: balanceInfo.pending || '0'
+                    };
+                    break;
+                case 'getAccountInfo':
+                    this.schemaValidator.validate(params, {
+                        type: 'object',
+                        required: ['address'],
+                        properties: {
+                            address: { type: 'string' }
+                        }
+                    });
+                    result = await this.nanoTransactions.getAccountInfo(params.address);
+                    break;
+                case 'getPendingBlocks':
+                    this.schemaValidator.validate(params, {
+                        type: 'object',
+                        required: ['address'],
+                        properties: {
+                            address: { type: 'string' }
+                        }
+                    });
+                    result = await this.nanoTransactions.getPendingBlocks(params.address);
+                    break;
+                case 'initializeAccount':
+                    this.schemaValidator.validate(params, {
+                        type: 'object',
+                        required: ['address', 'privateKey'],
+                        properties: {
+                            address: { type: 'string' },
+                            privateKey: { type: 'string' }
+                        }
+                    });
+                    result = await this.nanoTransactions.initializeAccount(params.address, params.privateKey);
+                    break;
+                case 'sendTransaction':
+                    this.schemaValidator.validate(params, {
+                        type: 'object',
+                        required: ['fromAddress', 'toAddress', 'amountRaw', 'privateKey'],
+                        properties: {
+                            fromAddress: { type: 'string' },
+                            toAddress: { type: 'string' },
+                            amountRaw: { type: 'string' },
+                            privateKey: { type: 'string' }
+                        }
+                    });
+                    result = await this.nanoTransactions.sendTransaction(
+                        params.fromAddress,
+                        params.toAddress,
+                        params.amountRaw,
+                        params.privateKey
+                    );
+                    break;
+                case 'receiveAllPending':
+                    this.schemaValidator.validate(params, {
+                        type: 'object',
+                        required: ['address', 'privateKey'],
+                        properties: {
+                            address: { type: 'string' },
+                            privateKey: { type: 'string' }
+                        }
+                    });
+                    result = await this.nanoTransactions.receiveAllPending(params.address, params.privateKey);
+                    break;
+                default:
+                    throw new Error(`Method ${method} not found`);
+            }
+
+            return {
+                jsonrpc: "2.0",
+                result,
+                id
+            };
+        } catch (error) {
+            return {
+                jsonrpc: "2.0",
+                error: {
+                    code: -32603,
+                    message: error.message
+                },
+                id: request.id
+            };
+        }
+    }
+
+    /**
+     * Starts the HTTP server
+     * @returns {http.Server} The HTTP server instance
+     * @throws {Error} When server fails to start
+     */
+    startHttp() {
+        const app = express();
+        app.use(bodyParser.json());
+        
+        // Swagger documentation
+        app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpecs));
+
+        // JSON-RPC endpoint
+        app.post('/', async (req, res) => {
+            const response = await this.handleRequest(req.body);
+            res.json(response);
+        });
+
+        // Start server
+        const server = http.createServer(app);
+        server.listen(this.config.port, () => {
+            console.log(`NANO MCP Server running on port ${this.config.port}`);
+            console.log(`API documentation available at http://localhost:${this.config.port}/api-docs`);
+        });
+
+        return server;
+    }
+}
+
+// Helper function to determine content type
+function getContentType(filePath) {
+    const ext = path.extname(filePath).toLowerCase();
+    const contentTypes = {
+        '.css': 'text/css',
+        '.js': 'application/javascript',
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif',
+        '.svg': 'image/svg+xml',
+        '.ico': 'image/x-icon'
+    };
+    return contentTypes[ext] || 'text/plain';
+}
+
+module.exports = { NanoMCPServer }; 

--- a/NANO_MCP_SERVER/src/stdio-transport.js
+++ b/NANO_MCP_SERVER/src/stdio-transport.js
@@ -1,0 +1,51 @@
+const readline = require('readline');
+
+class StdioTransport {
+    /**
+     * Creates a new stdio transport for NANO MCP Server
+     * @param {NanoMCPServer} server - The NANO MCP server instance
+     */
+    constructor(server) {
+        this.server = server;
+    }
+
+    /**
+     * Starts the stdio transport
+     */
+    start() {
+        console.error('NANO MCP Server running in stdio mode');
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', async (data) => {
+            try {
+                const request = JSON.parse(data);
+                const response = await this.server.handleRequest(request);
+                console.log(JSON.stringify(response));
+            } catch (error) {
+                console.error('Error processing request:', error);
+                console.log(JSON.stringify({
+                    jsonrpc: "2.0",
+                    error: {
+                        code: -32700,
+                        message: "Parse error"
+                    },
+                    id: null
+                }));
+            }
+        });
+
+        // Handle process termination
+        process.on('SIGINT', () => {
+            this.stop();
+            process.exit(0);
+        });
+    }
+
+    stop() {
+        // Close readline interface if it exists
+        if (this.rl) {
+            this.rl.close();
+        }
+    }
+}
+
+module.exports = { StdioTransport }; 

--- a/NANO_MCP_SERVER/src/swagger.js
+++ b/NANO_MCP_SERVER/src/swagger.js
@@ -1,0 +1,969 @@
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'NANO MCP API',
+      version: '1.0.0',
+      description: 'NANO MCP (NANO Cryptocurrency) Server API Documentation',
+      license: {
+        name: 'MIT',
+        url: 'https://github.com/dhyabi2/nano-mcp/blob/main/LICENSE'
+      }
+    },
+    servers: [
+      {
+        url: 'http://localhost:8080',
+        description: 'Development server'
+      },
+    ],
+    components: {
+      schemas: {
+        JsonRpcError: {
+          type: 'object',
+          required: ['jsonrpc', 'error', 'id'],
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            error: {
+              type: 'object',
+              required: ['code', 'message'],
+              properties: {
+                code: {
+                  type: 'number',
+                  description: 'Error code',
+                  example: -32603,
+                },
+                message: {
+                  type: 'string',
+                  description: 'Error message',
+                  example: 'Internal error',
+                },
+              },
+            },
+            id: {
+              type: ['number', 'string', 'null'],
+              description: 'Request identifier that generated the error',
+            },
+          },
+        },
+        JsonRpcRequest: {
+          type: 'object',
+          required: ['jsonrpc', 'method', 'id'],
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            method: {
+              type: 'string',
+              description: 'The method to call',
+            },
+            params: {
+              type: 'object',
+              description: 'Method parameters',
+            },
+            id: {
+              type: ['number', 'string'],
+              description: 'Request identifier',
+            },
+          },
+        },
+        JsonRpcResponse: {
+          type: 'object',
+          required: ['jsonrpc', 'id'],
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            result: {
+              type: 'object',
+              description: 'Response result',
+            },
+            error: {
+              type: 'object',
+              properties: {
+                code: {
+                  type: 'number',
+                  description: 'Error code',
+                },
+                message: {
+                  type: 'string',
+                  description: 'Error message',
+                },
+              },
+            },
+            id: {
+              type: ['number', 'string', 'null'],
+              description: 'Request identifier',
+            },
+          },
+        },
+        InitializeResponse: {
+          type: 'object',
+          properties: {
+            version: {
+              type: 'string',
+              example: '1.0.0',
+            },
+            capabilities: {
+              type: 'object',
+              properties: {
+                methods: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                  example: ['initialize', 'generateWallet', 'getBalance', 'initializeAccount', 'sendTransaction', 'receiveAllPending'],
+                },
+              },
+            },
+          },
+        },
+        WalletResponse: {
+          type: 'object',
+          properties: {
+            publicKey: {
+              type: 'string',
+              description: 'Public key of the wallet',
+            },
+            privateKey: {
+              type: 'string',
+              description: 'Private key of the wallet',
+            },
+            address: {
+              type: 'string',
+              description: 'Nano address',
+            },
+          },
+        },
+        BalanceResponse: {
+          type: 'object',
+          properties: {
+            balance: {
+              type: 'string',
+              description: 'Account balance in raw units',
+            },
+            pending: {
+              type: 'string',
+              description: 'Pending balance in raw units',
+            },
+          },
+        },
+        AccountInfoResponse: {
+          type: 'object',
+          properties: {
+            initialized: {
+              type: 'boolean',
+              description: 'Whether the account is initialized',
+            },
+            representative: {
+              type: 'string',
+              description: 'Account representative',
+            },
+          },
+        },
+        TransactionResponse: {
+          type: 'object',
+          properties: {
+            success: {
+              type: 'boolean',
+              description: 'Transaction success status',
+            },
+            hash: {
+              type: 'string',
+              description: 'Transaction hash',
+            },
+            amount: {
+              type: 'string',
+              description: 'Transaction amount in raw units',
+            },
+            balance: {
+              type: 'string',
+              description: 'Account balance after transaction',
+            },
+          },
+        },
+        ReceiveAllPendingResponse: {
+          type: 'object',
+          properties: {
+            received: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  hash: {
+                    type: 'string',
+                    description: 'Block hash',
+                  },
+                  amount: {
+                    type: 'string',
+                    description: 'Amount received in raw units',
+                  },
+                  source: {
+                    type: 'string',
+                    description: 'Source address',
+                  },
+                },
+              },
+            },
+          },
+        },
+        GetAccountInfoRequest: {
+          type: 'object',
+          required: ['jsonrpc', 'method', 'params', 'id'],
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            method: {
+              type: 'string',
+              enum: ['getAccountInfo'],
+              description: 'Method name',
+            },
+            params: {
+              type: 'object',
+              required: ['address'],
+              properties: {
+                address: {
+                  type: 'string',
+                  description: 'The Nano account address',
+                },
+              },
+            },
+            id: {
+              type: 'number',
+              description: 'Request identifier',
+            },
+          },
+        },
+        GetAccountInfoResponse: {
+          type: 'object',
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            result: {
+              type: 'object',
+              properties: {
+                frontier: {
+                  type: 'string',
+                  description: 'The latest block hash for the account',
+                },
+                open_block: {
+                  type: 'string',
+                  description: 'The first block hash for the account',
+                },
+                representative_block: {
+                  type: 'string',
+                  description: 'The representative block hash',
+                },
+                balance: {
+                  type: 'string',
+                  description: 'The account balance in raw',
+                },
+                modified_timestamp: {
+                  type: 'string',
+                  description: 'Last modified timestamp',
+                },
+                block_count: {
+                  type: 'string',
+                  description: 'Number of blocks in the account chain',
+                },
+                representative: {
+                  type: 'string',
+                  description: 'The account\'s representative',
+                },
+              },
+            },
+            id: {
+              type: 'number',
+              description: 'Request identifier',
+            },
+          },
+        },
+        GetPendingBlocksRequest: {
+          type: 'object',
+          required: ['jsonrpc', 'method', 'params', 'id'],
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            method: {
+              type: 'string',
+              enum: ['getPendingBlocks'],
+              description: 'Method name',
+            },
+            params: {
+              type: 'object',
+              required: ['address'],
+              properties: {
+                address: {
+                  type: 'string',
+                  description: 'The Nano account address',
+                },
+              },
+            },
+            id: {
+              type: 'number',
+              description: 'Request identifier',
+            },
+          },
+        },
+        GetPendingBlocksResponse: {
+          type: 'object',
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            result: {
+              type: 'object',
+              properties: {
+                blocks: {
+                  type: 'object',
+                  additionalProperties: {
+                    type: 'object',
+                    properties: {
+                      amount: {
+                        type: 'string',
+                        description: 'Amount in raw',
+                      },
+                      source: {
+                        type: 'string',
+                        description: 'Source account address',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            id: {
+              type: 'number',
+              description: 'Request identifier',
+            },
+          },
+        },
+        GenerateWorkRequest: {
+          type: 'object',
+          required: ['jsonrpc', 'method', 'params', 'id'],
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            method: {
+              type: 'string',
+              enum: ['generateWork'],
+              description: 'Method name',
+            },
+            params: {
+              type: 'object',
+              required: ['hash', 'isOpen'],
+              properties: {
+                hash: {
+                  type: 'string',
+                  description: 'The hash to generate work for',
+                },
+                isOpen: {
+                  type: 'boolean',
+                  description: 'Whether this is for an open block (lower difficulty)',
+                  default: false,
+                },
+              },
+            },
+            id: {
+              type: 'number',
+              description: 'Request identifier',
+            },
+          },
+        },
+        GenerateWorkResponse: {
+          type: 'object',
+          properties: {
+            jsonrpc: {
+              type: 'string',
+              enum: ['2.0'],
+              description: 'JSON-RPC version',
+            },
+            result: {
+              type: 'object',
+              properties: {
+                work: {
+                  type: 'string',
+                  description: 'The generated work value',
+                },
+              },
+            },
+            id: {
+              type: 'number',
+              description: 'Request identifier',
+            },
+          },
+        },
+      },
+      requestBodies: {
+        Initialize: {
+          description: 'Initialize request',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['jsonrpc', 'method', 'id'],
+                properties: {
+                  jsonrpc: {
+                    type: 'string',
+                    enum: ['2.0'],
+                    description: 'JSON-RPC version'
+                  },
+                  method: {
+                    type: 'string',
+                    enum: ['initialize'],
+                    description: 'Method name'
+                  },
+                  params: {
+                    type: 'object',
+                    description: 'No parameters required'
+                  },
+                  id: {
+                    type: 'number',
+                    description: 'Request identifier'
+                  }
+                }
+              },
+              example: {
+                jsonrpc: '2.0',
+                method: 'initialize',
+                params: {},
+                id: 1
+              }
+            }
+          }
+        },
+        GenerateWallet: {
+          description: 'Generate a new Nano wallet',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['jsonrpc', 'method', 'id'],
+                properties: {
+                  jsonrpc: {
+                    type: 'string',
+                    enum: ['2.0']
+                  },
+                  method: {
+                    type: 'string',
+                    enum: ['generateWallet']
+                  },
+                  params: {
+                    type: 'object',
+                    description: 'No parameters required'
+                  },
+                  id: {
+                    type: 'number'
+                  }
+                }
+              },
+              example: {
+                jsonrpc: '2.0',
+                method: 'generateWallet',
+                params: {},
+                id: 1
+              }
+            }
+          }
+        },
+        GetBalance: {
+          description: 'Get account balance',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['jsonrpc', 'method', 'params', 'id'],
+                properties: {
+                  jsonrpc: {
+                    type: 'string',
+                    enum: ['2.0']
+                  },
+                  method: {
+                    type: 'string',
+                    enum: ['getBalance']
+                  },
+                  params: {
+                    type: 'object',
+                    required: ['address'],
+                    properties: {
+                      address: {
+                        type: 'string',
+                        description: 'Nano address'
+                      }
+                    }
+                  },
+                  id: {
+                    type: 'number'
+                  }
+                }
+              },
+              example: {
+                jsonrpc: '2.0',
+                method: 'getBalance',
+                params: {
+                  address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3'
+                },
+                id: 1
+              }
+            }
+          }
+        },
+        InitializeAccount: {
+          description: 'Initialize a Nano account',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['jsonrpc', 'method', 'params', 'id'],
+                properties: {
+                  jsonrpc: {
+                    type: 'string',
+                    enum: ['2.0']
+                  },
+                  method: {
+                    type: 'string',
+                    enum: ['initializeAccount']
+                  },
+                  params: {
+                    type: 'object',
+                    required: ['address', 'privateKey'],
+                    properties: {
+                      address: {
+                        type: 'string',
+                        description: 'Nano address'
+                      },
+                      privateKey: {
+                        type: 'string',
+                        description: 'Private key'
+                      }
+                    }
+                  },
+                  id: {
+                    type: 'number'
+                  }
+                }
+              },
+              example: {
+                jsonrpc: '2.0',
+                method: 'initializeAccount',
+                params: {
+                  address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
+                  privateKey: '781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3'
+                },
+                id: 1
+              }
+            }
+          }
+        },
+        SendTransaction: {
+          description: 'Send Nano to another address',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['jsonrpc', 'method', 'params', 'id'],
+                properties: {
+                  jsonrpc: {
+                    type: 'string',
+                    enum: ['2.0']
+                  },
+                  method: {
+                    type: 'string',
+                    enum: ['sendTransaction']
+                  },
+                  params: {
+                    type: 'object',
+                    required: ['fromAddress', 'privateKey', 'toAddress', 'amountRaw'],
+                    properties: {
+                      fromAddress: {
+                        type: 'string',
+                        description: 'Sender Nano address'
+                      },
+                      privateKey: {
+                        type: 'string',
+                        description: 'Sender private key'
+                      },
+                      toAddress: {
+                        type: 'string',
+                        description: 'Recipient Nano address'
+                      },
+                      amountRaw: {
+                        type: 'string',
+                        description: 'Amount in raw units'
+                      }
+                    }
+                  },
+                  id: {
+                    type: 'number'
+                  }
+                }
+              },
+              example: {
+                jsonrpc: '2.0',
+                method: 'sendTransaction',
+                params: {
+                  fromAddress: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
+                  privateKey: '781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3',
+                  toAddress: 'nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est',
+                  amountRaw: '1000000000000000000000000000'
+                },
+                id: 1
+              }
+            }
+          }
+        },
+        ReceiveAllPending: {
+          description: 'Receive all pending transactions and update account balance. Funds will be actually received, not just marked as receivable.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['jsonrpc', 'method', 'params', 'id'],
+                properties: {
+                  jsonrpc: {
+                    type: 'string',
+                    enum: ['2.0']
+                  },
+                  method: {
+                    type: 'string',
+                    enum: ['receiveAllPending']
+                  },
+                  params: {
+                    type: 'object',
+                    required: ['address', 'privateKey'],
+                    properties: {
+                      address: {
+                        type: 'string',
+                        description: 'Nano address'
+                      },
+                      privateKey: {
+                        type: 'string',
+                        description: 'Private key'
+                      }
+                    }
+                  },
+                  id: {
+                    type: 'number'
+                  }
+                }
+              },
+              example: {
+                jsonrpc: '2.0',
+                method: 'receiveAllPending',
+                params: {
+                  address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
+                  privateKey: '781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3'
+                },
+                id: 1
+              }
+            }
+          }
+        }
+      }
+    },
+    paths: {
+      '/': {
+        post: {
+          summary: 'JSON-RPC 2.0 endpoint',
+          description: 'Handles all NANO MCP Server operations via JSON-RPC 2.0 protocol',
+          tags: ['NANO Operations'],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/JsonRpcRequest'
+                },
+                examples: {
+                  initialize: {
+                    summary: 'Initialize request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'initialize',
+                      params: {},
+                      id: 1
+                    }
+                  },
+                  generateWallet: {
+                    summary: 'Generate wallet request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'generateWallet',
+                      params: {},
+                      id: 1
+                    }
+                  },
+                  getBalance: {
+                    summary: 'Get balance request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'getBalance',
+                      params: {
+                        address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3'
+                      },
+                      id: 1
+                    }
+                  },
+                  initializeAccount: {
+                    summary: 'Initialize account request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'initializeAccount',
+                      params: {
+                        address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
+                        privateKey: '781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3'
+                      },
+                      id: 1
+                    }
+                  },
+                  sendTransaction: {
+                    summary: 'Send transaction request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'sendTransaction',
+                      params: {
+                        fromAddress: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
+                        privateKey: '781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3',
+                        toAddress: 'nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est',
+                        amountRaw: '1000000000000000000000000000'
+                      },
+                      id: 1
+                    }
+                  },
+                  receiveAllPending: {
+                    summary: 'Receive all pending request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'receiveAllPending',
+                      params: {
+                        address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3',
+                        privateKey: '781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3'
+                      },
+                      id: 1
+                    }
+                  },
+                  getAccountInfo: {
+                    summary: 'Get account info request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'getAccountInfo',
+                      params: {
+                        address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3'
+                      },
+                      id: 1
+                    }
+                  },
+                  getPendingBlocks: {
+                    summary: 'Get pending blocks request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'getPendingBlocks',
+                      params: {
+                        address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3'
+                      },
+                      id: 1
+                    }
+                  },
+                  generateWork: {
+                    summary: 'Generate work request',
+                    value: {
+                      jsonrpc: '2.0',
+                      method: 'generateWork',
+                      params: {
+                        hash: '000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F',
+                        isOpen: false
+                      },
+                      id: 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          responses: {
+            '200': {
+              description: 'JSON-RPC 2.0 response',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/JsonRpcResponse'
+                  },
+                  examples: {
+                    initialize: {
+                      summary: 'Initialize response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          version: '1.0.0',
+                          capabilities: {
+                            methods: [
+                              'initialize',
+                              'generateWallet',
+                              'getBalance',
+                              'initializeAccount',
+                              'sendTransaction',
+                              'receiveAllPending'
+                            ]
+                          }
+                        },
+                        id: 1
+                      }
+                    },
+                    generateWallet: {
+                      summary: 'Generate wallet response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          publicKey: '9D473FD0CAD0D08C29E6C68CC449976A7E2BFBB3DC6177343023B0E277C56374',
+                          privateKey: '781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3',
+                          address: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3'
+                        },
+                        id: 1
+                      }
+                    },
+                    getBalance: {
+                      summary: 'Get balance response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          balance: '1000000000000000000000000000',
+                          pending: '0'
+                        },
+                        id: 1
+                      }
+                    },
+                    initializeAccount: {
+                      summary: 'Initialize account response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          initialized: true,
+                          representative: 'nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou'
+                        },
+                        id: 1
+                      }
+                    },
+                    sendTransaction: {
+                      summary: 'Send transaction response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          success: true,
+                          hash: '000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F',
+                          amount: '1000000000000000000000000000',
+                          balance: '0'
+                        },
+                        id: 1
+                      }
+                    },
+                    receiveAllPending: {
+                      summary: 'Receive all pending response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          received: [
+                            {
+                              hash: '000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F',
+                              amount: '1000000000000000000000000000',
+                              source: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3'
+                            }
+                          ]
+                        },
+                        id: 1
+                      }
+                    },
+                    getAccountInfo: {
+                      summary: 'Get account info response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          frontier: '000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F',
+                          open_block: '000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F',
+                          representative_block: '000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F',
+                          balance: '1000000000000000000000000000',
+                          modified_timestamp: '1633072800',
+                          block_count: '100',
+                          representative: 'nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou'
+                        },
+                        id: 1
+                      }
+                    },
+                    getPendingBlocks: {
+                      summary: 'Get pending blocks response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          blocks: {
+                            '000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F': {
+                              amount: '1000000000000000000000000000',
+                              source: 'nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3'
+                            }
+                          }
+                        },
+                        id: 1
+                      }
+                    },
+                    generateWork: {
+                      summary: 'Generate work response',
+                      value: {
+                        jsonrpc: '2.0',
+                        result: {
+                          work: '0000000000000000000000000000000000000000000000000000000000000000'
+                        },
+                        id: 1
+                      }
+                    }
+                  }
+                },
+              },
+            },
+            '400': {
+              description: 'Invalid request',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/ErrorResponse'
+                  },
+                  example: {
+                    jsonrpc: '2.0',
+                    error: {
+                      code: -32603,
+                      message: 'Invalid parameters'
+                    },
+                    id: null
+                  }
+                }
+              }
+            }
+          }
+        },
+      },
+    },
+  },
+  apis: ['./src/*.js']
+};
+
+module.exports = swaggerJsdoc(options); 

--- a/NANO_MCP_SERVER/tests/full-flow-test.ps1
+++ b/NANO_MCP_SERVER/tests/full-flow-test.ps1
@@ -1,0 +1,391 @@
+# Colors for better visibility
+$Green = [System.ConsoleColor]::Green
+$Yellow = [System.ConsoleColor]::Yellow
+$Red = [System.ConsoleColor]::Red
+
+Write-Host "Starting NANO MCP Full Flow Test" -ForegroundColor $Green
+Write-Host "----------------------------------------"
+
+# Function to make JSON-RPC calls
+function Invoke-RPC {
+    param (
+        [string]$JsonData
+    )
+    try {
+        $response = Invoke-RestMethod -Uri "http://localhost:8080/" `
+            -Method Post `
+            -Headers @{"Content-Type"="application/json"} `
+            -Body $JsonData
+        return $response
+    }
+    catch {
+        Write-Host "Error making RPC call:" -ForegroundColor $Red
+        Write-Host "Request: $JsonData" -ForegroundColor $Red
+        Write-Host "Error: $_" -ForegroundColor $Red
+        return $null
+    }
+}
+
+# Function to load wallets from file
+function Load-Wallets {
+    $walletsFile = "tests/wallets.json"
+    if (Test-Path $walletsFile) {
+        try {
+            $wallets = Get-Content $walletsFile | ConvertFrom-Json
+            return $wallets
+        }
+        catch {
+            Write-Host "Error loading wallets file: $_" -ForegroundColor $Red
+            return $null
+        }
+    }
+    return $null
+}
+
+# Function to save wallets to file
+function Save-Wallets {
+    param (
+        $wallet1,
+        $wallet2
+    )
+    $walletsFile = "tests/wallets.json"
+    $wallets = @{
+        wallet1 = @{
+            address = $wallet1.address
+            privateKey = $wallet1.privateKey
+        }
+        wallet2 = @{
+            address = $wallet2.address
+            privateKey = $wallet2.privateKey
+        }
+    }
+    $maxRetries = 5
+    $retryCount = 0
+    $success = $false
+
+    while (-not $success -and $retryCount -lt $maxRetries) {
+        try {
+            $wallets | ConvertTo-Json | Set-Content $walletsFile -ErrorAction Stop
+            $success = $true
+        }
+        catch {
+            $retryCount++
+            if ($retryCount -lt $maxRetries) {
+                Write-Host "Failed to save wallets, retrying in 1 second... (Attempt $retryCount of $maxRetries)" -ForegroundColor $Yellow
+                Start-Sleep -Seconds 1
+            }
+            else {
+                Write-Host "Failed to save wallets after $maxRetries attempts" -ForegroundColor $Red
+            }
+        }
+    }
+}
+
+# Function to convert raw to NANO
+function Convert-RawToNano {
+    param (
+        [string]$rawAmount
+    )
+    try {
+        if ($rawAmount -eq "0") { return "0" }
+        
+        # Remove any trailing zeros
+        $trimmed = $rawAmount.TrimEnd('0')
+        
+        # If length is less than 30, pad with zeros on the left
+        if ($trimmed.Length -lt 30) {
+            return "0." + $trimmed.PadLeft(30, '0')
+        }
+        
+        # If length is 30 or more, insert decimal point 30 places from the right
+        $decimalPos = $trimmed.Length - 30
+        return $trimmed.Insert($decimalPos, ".")
+    }
+    catch {
+        return "Error converting amount"
+    }
+}
+
+# Initialize server
+Write-Host "Initializing server..." -ForegroundColor $Yellow
+$initJson = @{
+    jsonrpc = "2.0"
+    method = "initialize"
+    params = @{}
+    id = 1
+} | ConvertTo-Json
+$initResponse = Invoke-RPC -JsonData $initJson
+if ($null -eq $initResponse) {
+    Write-Host "Failed to initialize server. Exiting..." -ForegroundColor $Red
+    exit 1
+}
+Write-Host "Server initialized successfully"
+Write-Host "----------------------------------------"
+
+# Load or Generate Wallets
+$savedWallets = Load-Wallets
+$wallet1 = $null
+$wallet2 = $null
+
+if ($null -ne $savedWallets -and $savedWallets.wallet1.address -ne "") {
+    Write-Host "Loading saved Wallet 1..." -ForegroundColor $Yellow
+    $wallet1 = @{
+        address = $savedWallets.wallet1.address
+        privateKey = $savedWallets.wallet1.privateKey
+    }
+    Write-Host "Wallet 1 loaded successfully"
+} else {
+    Write-Host "Generating new Wallet 1..." -ForegroundColor $Yellow
+    $wallet1Json = @{
+        jsonrpc = "2.0"
+        method = "generateWallet"
+        params = @{}
+        id = 1
+    } | ConvertTo-Json
+    $wallet1Response = Invoke-RPC -JsonData $wallet1Json
+    if ($null -eq $wallet1Response) {
+        Write-Host "Failed to generate Wallet 1. Exiting..." -ForegroundColor $Red
+        exit 1
+    }
+    $wallet1 = @{
+        address = $wallet1Response.result.address
+        privateKey = $wallet1Response.result.privateKey
+    }
+    Write-Host "New Wallet 1 generated successfully"
+}
+
+Write-Host "Wallet 1 Address: $($wallet1.address)"
+Write-Host "----------------------------------------"
+
+# Initialize Wallet 1
+Write-Host "Initializing Wallet 1..." -ForegroundColor $Yellow
+$initWallet1Json = @{
+    jsonrpc = "2.0"
+    method = "initializeAccount"
+    params = @{
+        address = $wallet1.address
+        privateKey = $wallet1.privateKey
+    }
+    id = 1
+} | ConvertTo-Json
+$initWallet1Response = Invoke-RPC -JsonData $initWallet1Json
+if ($null -eq $initWallet1Response) {
+    Write-Host "Failed to initialize Wallet 1. Exiting..." -ForegroundColor $Red
+    exit 1
+}
+Write-Host "Wallet 1 initialized successfully"
+Write-Host "----------------------------------------"
+
+# Wait for initial funds (0.0001 NANO)
+Write-Host "Waiting for initial funds to Wallet 1..." -ForegroundColor $Yellow
+Write-Host "Please send 0.0001 NANO to: $($wallet1.address)"
+Write-Host "Checking for incoming transaction every 10 seconds..."
+
+$transactionReceived = $false
+while (-not $transactionReceived) {
+    # Check balance
+    $balanceJson = @{
+        jsonrpc = "2.0"
+        method = "getBalance"
+        params = @{
+            address = $wallet1.address
+        }
+        id = 1
+    } | ConvertTo-Json
+    $balanceResponse = Invoke-RPC -JsonData $balanceJson
+    
+    # Check pending blocks
+    $pendingJson = @{
+        jsonrpc = "2.0"
+        method = "getPendingBlocks"
+        params = @{
+            address = $wallet1.address
+        }
+        id = 1
+    } | ConvertTo-Json
+    $pendingResponse = Invoke-RPC -JsonData $pendingJson
+    
+    Write-Host "`nDebug Info:" -ForegroundColor $Yellow
+    Write-Host "Balance Response: $($balanceResponse | ConvertTo-Json -Depth 10)"
+    Write-Host "Pending Response: $($pendingResponse | ConvertTo-Json -Depth 10)"
+    
+    # Check if we have any balance or pending blocks
+    if ($null -ne $balanceResponse -and 
+        $null -ne $balanceResponse.result -and 
+        $balanceResponse.result.balance -gt 0) {
+        Write-Host "Balance detected: $($balanceResponse.result.balance) raw" -ForegroundColor $Green
+        $transactionReceived = $true
+        break
+    }
+    
+    if ($null -ne $pendingResponse -and 
+        $null -ne $pendingResponse.result -and 
+        $null -ne $pendingResponse.result.blocks -and 
+        @($pendingResponse.result.blocks).Count -gt 0) {
+        Write-Host "Pending blocks detected!" -ForegroundColor $Green
+        Write-Host "Processing pending blocks..." -ForegroundColor $Yellow
+        $receiveJson = @{
+            jsonrpc = "2.0"
+            method = "receiveAllPending"
+            params = @{
+                address = $wallet1.address
+                privateKey = $wallet1.privateKey
+            }
+            id = 1
+        } | ConvertTo-Json
+        $receiveResponse = Invoke-RPC -JsonData $receiveJson
+        Write-Host "Receive Response: $($receiveResponse | ConvertTo-Json -Depth 10)"
+        $transactionReceived = $true
+        break
+    }
+    
+    Write-Host "No transaction yet. Checking again in 10 seconds..." -ForegroundColor $Yellow
+    Start-Sleep -Seconds 10
+}
+
+Write-Host "Transaction confirmed successfully!" -ForegroundColor $Green
+Write-Host "----------------------------------------"
+
+# Load or Generate Wallet 2
+if ($null -ne $savedWallets -and $savedWallets.wallet2.address -ne "") {
+    Write-Host "Loading saved Wallet 2..." -ForegroundColor $Yellow
+    $wallet2 = @{
+        address = $savedWallets.wallet2.address
+        privateKey = $savedWallets.wallet2.privateKey
+    }
+    Write-Host "Wallet 2 loaded successfully"
+} else {
+    Write-Host "Generating new Wallet 2..." -ForegroundColor $Yellow
+    $wallet2Json = @{
+        jsonrpc = "2.0"
+        method = "generateWallet"
+        params = @{}
+        id = 1
+    } | ConvertTo-Json
+    $wallet2Response = Invoke-RPC -JsonData $wallet2Json
+    if ($null -eq $wallet2Response) {
+        Write-Host "Failed to generate Wallet 2. Exiting..." -ForegroundColor $Red
+        exit 1
+    }
+    $wallet2 = @{
+        address = $wallet2Response.result.address
+        privateKey = $wallet2Response.result.privateKey
+    }
+    Write-Host "New Wallet 2 generated successfully"
+}
+
+Write-Host "Wallet 2 Address: $($wallet2.address)"
+Write-Host "----------------------------------------"
+
+# Initialize Wallet 2
+Write-Host "Initializing Wallet 2..." -ForegroundColor $Yellow
+$initWallet2Json = @{
+    jsonrpc = "2.0"
+    method = "initializeAccount"
+    params = @{
+        address = $wallet2.address
+        privateKey = $wallet2.privateKey
+    }
+    id = 1
+} | ConvertTo-Json
+$initWallet2Response = Invoke-RPC -JsonData $initWallet2Json
+if ($null -eq $initWallet2Response) {
+    Write-Host "Failed to initialize Wallet 2. Exiting..." -ForegroundColor $Red
+    exit 1
+}
+Write-Host "Wallet 2 initialized successfully"
+Write-Host "----------------------------------------"
+
+# Save both wallets
+Save-Wallets -wallet1 $wallet1 -wallet2 $wallet2
+
+# Send 0.00005 NANO from Wallet 1 to Wallet 2
+Write-Host "Sending 0.00005 NANO from Wallet 1 to Wallet 2..." -ForegroundColor $Yellow
+$sendJson = @{
+    jsonrpc = "2.0"
+    method = "sendTransaction"
+    params = @{
+        fromAddress = $wallet1.address
+        toAddress = $wallet2.address
+        amountRaw = "50000000000000000000000"
+        privateKey = $wallet1.privateKey
+    }
+    id = 1
+} | ConvertTo-Json
+$sendResponse = Invoke-RPC -JsonData $sendJson
+Write-Host "Transaction sent successfully"
+Write-Host "----------------------------------------"
+
+# Wait for Wallet 2 to receive
+Write-Host "Waiting for Wallet 2 to receive funds..." -ForegroundColor $Yellow
+Start-Sleep -Seconds 5
+
+# Receive funds in Wallet 2
+Write-Host "Receiving funds in Wallet 2..." -ForegroundColor $Yellow
+$receiveJson = @{
+    jsonrpc = "2.0"
+    method = "receiveAllPending"
+    params = @{
+        address = $wallet2.address
+        privateKey = $wallet2.privateKey
+    }
+    id = 1
+} | ConvertTo-Json
+$receiveResponse = Invoke-RPC -JsonData $receiveJson
+Write-Host "Funds received in Wallet 2 successfully"
+Write-Host "----------------------------------------"
+
+# Final balance check
+Write-Host "Checking final balances..." -ForegroundColor $Yellow
+
+# Get account info for Wallet 1
+$wallet1InfoJson = @{
+    jsonrpc = "2.0"
+    method = "getAccountInfo"
+    params = @{
+        address = $wallet1.address
+    }
+    id = 1
+} | ConvertTo-Json
+$wallet1Info = Invoke-RPC -JsonData $wallet1InfoJson
+Write-Host "`nWallet 1 Account Info:" -ForegroundColor $Yellow
+Write-Host $($wallet1Info | ConvertTo-Json -Depth 10)
+
+# Get account info for Wallet 2
+$wallet2InfoJson = @{
+    jsonrpc = "2.0"
+    method = "getAccountInfo"
+    params = @{
+        address = $wallet2.address
+    }
+    id = 1
+} | ConvertTo-Json
+$wallet2Info = Invoke-RPC -JsonData $wallet2InfoJson
+Write-Host "`nWallet 2 Account Info:" -ForegroundColor $Yellow
+Write-Host $($wallet2Info | ConvertTo-Json -Depth 10)
+
+# Get balance for Wallet 1
+$wallet1FinalBalanceJson = @{
+    jsonrpc = "2.0"
+    method = "getBalance"
+    params = @{
+        address = $wallet1.address
+    }
+    id = 1
+} | ConvertTo-Json
+$wallet1FinalBalance = Invoke-RPC -JsonData $wallet1FinalBalanceJson
+
+# Get balance for Wallet 2
+$wallet2FinalBalanceJson = @{
+    jsonrpc = "2.0"
+    method = "getBalance"
+    params = @{
+        address = $wallet2.address
+    }
+    id = 1
+} | ConvertTo-Json
+$wallet2FinalBalance = Invoke-RPC -JsonData $wallet2FinalBalanceJson
+
+Write-Host "`nTest Complete!" -ForegroundColor $Green
+Write-Host "Wallet 1 final balance: $($wallet1FinalBalance.result.balance) raw ($(Convert-RawToNano $wallet1FinalBalance.result.balance) NANO)"
+Write-Host "Wallet 2 final balance: $($wallet2FinalBalance.result.balance) raw ($(Convert-RawToNano $wallet2FinalBalance.result.balance) NANO)" 

--- a/NANO_MCP_SERVER/tests/full-flow-test.sh
+++ b/NANO_MCP_SERVER/tests/full-flow-test.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+# Colors for better visibility
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}Starting NANO MCP Full Flow Test${NC}"
+echo "----------------------------------------"
+
+# Function to make JSON-RPC calls
+call_rpc() {
+    curl -s -X POST http://localhost:8080/ \
+        -H "Content-Type: application/json" \
+        -d "$1"
+}
+
+# Initialize server
+echo -e "${YELLOW}Initializing server...${NC}"
+INIT_RESPONSE=$(call_rpc '{
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "params": {},
+    "id": 1
+}')
+echo "Server initialized: $INIT_RESPONSE"
+echo "----------------------------------------"
+
+# Generate Wallet 1
+echo -e "${YELLOW}Generating Wallet 1...${NC}"
+WALLET1_RESPONSE=$(call_rpc '{
+    "jsonrpc": "2.0",
+    "method": "generateWallet",
+    "params": {},
+    "id": 1
+}')
+WALLET1_ADDRESS=$(echo $WALLET1_RESPONSE | jq -r '.result.address')
+WALLET1_PRIVATE_KEY=$(echo $WALLET1_RESPONSE | jq -r '.result.privateKey')
+echo "Wallet 1 Address: $WALLET1_ADDRESS"
+echo "----------------------------------------"
+
+# Initialize Wallet 1
+echo -e "${YELLOW}Initializing Wallet 1...${NC}"
+INIT_WALLET1_RESPONSE=$(call_rpc "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"initializeAccount\",
+    \"params\": {
+        \"address\": \"$WALLET1_ADDRESS\",
+        \"privateKey\": \"$WALLET1_PRIVATE_KEY\"
+    },
+    \"id\": 1
+}")
+echo "Wallet 1 initialized: $INIT_WALLET1_RESPONSE"
+echo "----------------------------------------"
+
+# Wait for initial funds (0.0001 NANO)
+echo -e "${YELLOW}Waiting for initial funds to Wallet 1...${NC}"
+echo "Please send 0.0001 NANO to: $WALLET1_ADDRESS"
+echo "Checking balance every 10 seconds for 4 minutes..."
+
+for i in {1..24}; do
+    BALANCE_RESPONSE=$(call_rpc "{
+        \"jsonrpc\": \"2.0\",
+        \"method\": \"getBalance\",
+        \"params\": {
+            \"address\": \"$WALLET1_ADDRESS\"
+        },
+        \"id\": 1
+    }")
+    PENDING_RESPONSE=$(call_rpc "{
+        \"jsonrpc\": \"2.0\",
+        \"method\": \"getPendingBlocks\",
+        \"params\": {
+            \"address\": \"$WALLET1_ADDRESS\"
+        },
+        \"id\": 1
+    }")
+    
+    echo "Check $i/24 - Balance: $BALANCE_RESPONSE"
+    echo "Pending blocks: $PENDING_RESPONSE"
+    
+    # If pending blocks exist, receive them
+    if [ "$(echo $PENDING_RESPONSE | jq '.result')" != "[]" ]; then
+        echo -e "${GREEN}Pending blocks found! Receiving...${NC}"
+        RECEIVE_RESPONSE=$(call_rpc "{
+            \"jsonrpc\": \"2.0\",
+            \"method\": \"receiveAllPending\",
+            \"params\": {
+                \"address\": \"$WALLET1_ADDRESS\",
+                \"privateKey\": \"$WALLET1_PRIVATE_KEY\"
+            },
+            \"id\": 1
+        }")
+        echo "Receive response: $RECEIVE_RESPONSE"
+        break
+    fi
+    
+    sleep 10
+done
+
+# Generate Wallet 2
+echo -e "${YELLOW}Generating Wallet 2...${NC}"
+WALLET2_RESPONSE=$(call_rpc '{
+    "jsonrpc": "2.0",
+    "method": "generateWallet",
+    "params": {},
+    "id": 1
+}')
+WALLET2_ADDRESS=$(echo $WALLET2_RESPONSE | jq -r '.result.address')
+WALLET2_PRIVATE_KEY=$(echo $WALLET2_RESPONSE | jq -r '.result.privateKey')
+echo "Wallet 2 Address: $WALLET2_ADDRESS"
+echo "----------------------------------------"
+
+# Initialize Wallet 2
+echo -e "${YELLOW}Initializing Wallet 2...${NC}"
+INIT_WALLET2_RESPONSE=$(call_rpc "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"initializeAccount\",
+    \"params\": {
+        \"address\": \"$WALLET2_ADDRESS\",
+        \"privateKey\": \"$WALLET2_PRIVATE_KEY\"
+    },
+    \"id\": 1
+}")
+echo "Wallet 2 initialized: $INIT_WALLET2_RESPONSE"
+echo "----------------------------------------"
+
+# Send 0.00005 NANO from Wallet 1 to Wallet 2
+echo -e "${YELLOW}Sending 0.00005 NANO from Wallet 1 to Wallet 2...${NC}"
+SEND_RESPONSE=$(call_rpc "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"sendTransaction\",
+    \"params\": {
+        \"fromAddress\": \"$WALLET1_ADDRESS\",
+        \"toAddress\": \"$WALLET2_ADDRESS\",
+        \"amountRaw\": \"50000000000000000000000\",
+        \"privateKey\": \"$WALLET1_PRIVATE_KEY\"
+    },
+    \"id\": 1
+}")
+echo "Send response: $SEND_RESPONSE"
+echo "----------------------------------------"
+
+# Wait for Wallet 2 to receive
+echo -e "${YELLOW}Waiting for Wallet 2 to receive funds...${NC}"
+sleep 5
+
+# Receive funds in Wallet 2
+echo -e "${YELLOW}Receiving funds in Wallet 2...${NC}"
+RECEIVE_WALLET2_RESPONSE=$(call_rpc "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"receiveAllPending\",
+    \"params\": {
+        \"address\": \"$WALLET2_ADDRESS\",
+        \"privateKey\": \"$WALLET2_PRIVATE_KEY\"
+    },
+    \"id\": 1
+}")
+echo "Wallet 2 receive response: $RECEIVE_WALLET2_RESPONSE"
+echo "----------------------------------------"
+
+# Final balance check for both wallets
+echo -e "${YELLOW}Final balance check...${NC}"
+WALLET1_FINAL_BALANCE=$(call_rpc "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"getBalance\",
+    \"params\": {
+        \"address\": \"$WALLET1_ADDRESS\"
+    },
+    \"id\": 1
+}")
+WALLET2_FINAL_BALANCE=$(call_rpc "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"getBalance\",
+    \"params\": {
+        \"address\": \"$WALLET2_ADDRESS\"
+    },
+    \"id\": 1
+}")
+
+echo -e "${GREEN}Test Complete!${NC}"
+echo "Wallet 1 final balance: $WALLET1_FINAL_BALANCE"
+echo "Wallet 2 final balance: $WALLET2_FINAL_BALANCE" 

--- a/NANO_MCP_SERVER/tests/package.json
+++ b/NANO_MCP_SERVER/tests/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@chainreactionom/nano-mcp-server": "^1.0.10",
+    "nano-mcp": "^1.2.4",
+    "nanocurrency-web": "^1.4.3"
+  }
+}

--- a/NANO_MCP_SERVER/tests/test-receive.js
+++ b/NANO_MCP_SERVER/tests/test-receive.js
@@ -1,0 +1,202 @@
+const https = require('https');
+const { wallet, tools, block } = require('nanocurrency-web');
+
+// Helper function to make RPC calls
+async function makeRPCCall(action, params) {
+    return new Promise((resolve, reject) => {
+        const data = JSON.stringify({
+            action,
+            ...params,
+            key: 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23'
+        });
+
+        console.log('Making RPC call:', JSON.parse(data));
+
+        const options = {
+            hostname: 'rpc.nano.to',
+            port: 443,
+            path: '/',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': data.length
+            }
+        };
+
+        const req = https.request(options, (res) => {
+            let responseData = '';
+
+            res.on('data', (chunk) => {
+                responseData += chunk;
+            });
+
+            res.on('end', () => {
+                try {
+                    const jsonResponse = JSON.parse(responseData);
+                    console.log('RPC Response:', jsonResponse);
+                    resolve(jsonResponse);
+                } catch (error) {
+                    reject(new Error(`Failed to parse response: ${error.message}`));
+                }
+            });
+        });
+
+        req.on('error', (error) => {
+            reject(error);
+        });
+
+        req.write(data);
+        req.end();
+    });
+}
+
+// Helper function to wait for a specified time
+function wait(minutes) {
+    return new Promise(resolve => setTimeout(resolve, minutes * 60 * 1000));
+}
+
+async function testReceiveScenario() {
+    try {
+        // Step 1: Generate wallet
+        console.log('1. Generating new wallet...');
+        
+        // Generate a new wallet using nanocurrency-web
+        const walletData = wallet.generateLegacy();
+        const account = walletData.accounts[0].address;
+        const privateKey = walletData.accounts[0].privateKey;
+        const publicKey = walletData.accounts[0].publicKey;
+        const seed = walletData.seed;
+        
+        console.log('\nWallet generated successfully!');
+        console.log('Seed (KEEP THIS SAFE):', seed);
+        console.log('Account Address:', account);
+        console.log('Public Key:', publicKey);
+        console.log('Private Key:', privateKey);
+
+        // Step 2: Initialize the account
+        console.log('\n2. Checking account info...');
+        const initResult = await makeRPCCall('account_info', {
+            account: account
+        });
+        
+        if (initResult.error) {
+            console.log('Account not yet initialized (This is normal for new accounts)');
+        } else {
+            console.log('Account info:', initResult);
+        }
+
+        // Step 3: Wait for funds
+        console.log('\n3. Waiting for funds...');
+        console.log(`Please send exactly 0.00001 NANO to this address:\n${account}`);
+        console.log('\nWaiting 4 minutes for funds to arrive...');
+        
+        // Wait for 4 minutes
+        for (let i = 0; i < 4; i++) {
+            await wait(1);
+            console.log(`${3 - i} minutes remaining...`);
+            
+            // Check for pending during wait
+            const checkPending = await makeRPCCall('pending', {
+                account: account,
+                count: '1',
+                source: 'true'
+            });
+            
+            if (checkPending.blocks && Object.keys(checkPending.blocks).length > 0) {
+                console.log('\nPending transaction detected!');
+                break;
+            }
+        }
+
+        // Step 4: Check for pending blocks
+        console.log('\n4. Checking for pending blocks...');
+        const pendingResult = await makeRPCCall('pending', {
+            account: account,
+            count: '1',
+            source: 'true'
+        });
+        console.log('Pending blocks:', pendingResult);
+
+        if (pendingResult.blocks && Object.keys(pendingResult.blocks).length > 0) {
+            // Step 5: Generate work for receiving
+            console.log('\n5. Generating work...');
+            const workResult = await makeRPCCall('work_generate', {
+                hash: publicKey, // For first receive, use public key as frontier
+                key: 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23'
+            });
+            console.log('Work generated:', workResult);
+
+            if (!workResult.work) {
+                throw new Error('Failed to generate work');
+            }
+
+            // Step 6: Process pending blocks
+            console.log('\n6. Processing pending blocks...');
+            for (const [hash, blockInfo] of Object.entries(pendingResult.blocks)) {
+                // Convert raw amount to nano for display
+                const rawToNanoResult = await makeRPCCall('raw_to_nano', {
+                    amount: blockInfo.amount
+                });
+                console.log(`Receiving ${rawToNanoResult.nano} NANO from block ${hash}`);
+
+                // Create and sign the receive block using nanocurrency-web
+                const receiveBlockData = {
+                    walletBalanceRaw: '0', // Initial balance is 0 for first receive
+                    toAddress: account,
+                    representativeAddress: account, // Using self as representative for test
+                    frontier: '0000000000000000000000000000000000000000000000000000000000000000', // Genesis frontier for first receive
+                    transactionHash: hash,
+                    amountRaw: blockInfo.amount,
+                    work: workResult.work
+                };
+
+                // Create and sign the block
+                const signedBlock = block.receive(receiveBlockData, privateKey);
+
+                // Process the signed block
+                const processResult = await makeRPCCall('process', {
+                    json_block: 'true',
+                    subtype: 'receive',
+                    block: signedBlock
+                });
+                console.log('Block processed:', processResult);
+            }
+
+            // Step 7: Final balance check
+            console.log('\n7. Checking final balance...');
+            const balanceResult = await makeRPCCall('account_balance', {
+                account: account
+            });
+            
+            if (balanceResult.balance) {
+                const finalBalanceNano = await makeRPCCall('raw_to_nano', {
+                    amount: balanceResult.balance
+                });
+                console.log('Final balance:', finalBalanceNano.nano, 'NANO');
+            } else {
+                console.log('Final balance:', balanceResult);
+            }
+        } else {
+            console.log('No pending blocks found after waiting');
+        }
+
+    } catch (error) {
+        console.error('\nError occurred during test:');
+        console.error('Message:', error.message);
+        if (error.response) {
+            console.error('RPC Response:', error.response.data);
+        }
+        throw error;
+    }
+}
+
+// Run the test
+console.log('Starting NANO receive test scenario...\n');
+testReceiveScenario()
+    .then(() => {
+        console.log('\nTest completed successfully');
+    })
+    .catch(err => {
+        console.error('\nTest failed with error:', err);
+        process.exit(1);
+    }); 

--- a/NANO_MCP_SERVER/tests/test-send.js
+++ b/NANO_MCP_SERVER/tests/test-send.js
@@ -1,0 +1,92 @@
+const { NanoTransactions } = require('nano-mcp/dist/utils/nano-transactions');
+
+// Mock config object for testing
+const mockConfig = {
+    getNanoConfig: () => ({
+        rpcUrl: 'https://rpc.nano.to',
+        rpcKey: 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23',
+        gpuKey: '',
+        defaultRepresentative: 'nano_3arg3asgtigae3xckabaaewkx3bzsh7nwz7jkmjos79ihyaxwphhm6qgjps4'
+    }),
+    validateConfig: () => []
+};
+
+// Helper function to wait and check balance
+async function waitForBalance(nanoTx, address, timeoutSeconds = 120) {
+    console.log(`\nWaiting up to ${timeoutSeconds} seconds for funds...`);
+    const startTime = Date.now();
+    const endTime = startTime + (timeoutSeconds * 1000);
+
+    while (Date.now() < endTime) {
+        const secondsLeft = Math.round((endTime - Date.now()) / 1000);
+        console.log(`${secondsLeft} seconds remaining...`);
+
+        const checkBalance = await nanoTx.makeRequest('account_balance', {
+            account: address
+        });
+
+        // If there are pending funds, receive them
+        if (checkBalance.pending !== '0' || checkBalance.receivable !== '0') {
+            console.log('\nPending funds detected!');
+            return checkBalance;
+        }
+
+        // Wait 10 seconds before next check
+        await new Promise(resolve => setTimeout(resolve, 10000));
+    }
+
+    return null;
+}
+
+async function testSendScenario() {
+    console.log('Starting NANO send test scenario...');
+    
+    // Initialize source wallet
+    const sourceWallet = {
+        seed: '4479c1cd3ba579b541995111459177e5c49765dab19eaa0062cd659b44a2021b',
+        account: 'nano_31f9ptrsorqactjzqep53iixe5kdrbzbkuobz8w1wg7uabzgfhcpxbc4ssgu',
+        privateKey: 'adaf9e5f8d619b4fa92ddefae84adc07a50b79ff158405aa8b77920e649e44cc'
+    };
+    
+    console.log('Source wallet address:', sourceWallet.account);
+    
+    // Generate destination wallet
+    const destinationWallet = await new NanoTransactions({}, mockConfig).generateWallet();
+    console.log('Generated destination wallet:', destinationWallet.address);
+    
+    // Check initial balances
+    console.log('\nChecking initial balances...');
+    const sourceBalance = await new NanoTransactions({}, mockConfig).makeRequest('account_balance', {
+        account: sourceWallet.account
+    });
+    console.log('Source account balance:', sourceBalance);
+    
+    // Send funds to destination
+    console.log('\nSending funds to destination...');
+    const nanoTransactions = new NanoTransactions({}, mockConfig);
+    const sendAmount = '10000000000000000000000000'; // 0.00001 NANO
+    const sendResult = await nanoTransactions.sendTransaction(
+        sourceWallet.account,
+        sourceWallet.privateKey,
+        destinationWallet.address,
+        sendAmount
+    );
+    console.log('Send result:', sendResult);
+    
+    // Check final balances
+    console.log('\nChecking final balances...');
+    const finalSourceBalance = await nanoTransactions.makeRequest('account_balance', {
+        account: sourceWallet.account
+    });
+    const finalDestBalance = await nanoTransactions.makeRequest('account_balance', {
+        account: destinationWallet.address
+    });
+    
+    console.log('Final source balance:', finalSourceBalance);
+    console.log('Final destination balance:', finalDestBalance);
+    
+    console.log('\nTest completed.');
+}
+
+// Run the test
+testSendScenario().catch(console.error); 

--- a/NANO_MCP_SERVER/tests/transport-test.js
+++ b/NANO_MCP_SERVER/tests/transport-test.js
@@ -1,0 +1,127 @@
+const http = require('http');
+const { spawn } = require('child_process');
+const path = require('path');
+const NanoMCPServer = require('../src/NanoMCPServer');
+
+// Test request
+const testRequest = {
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {},
+    id: 1
+};
+
+// Test HTTP transport
+async function testHttpTransport() {
+    console.log('Testing HTTP transport...');
+    
+    // Start server
+    const server = new NanoMCPServer({
+        port: 8080,
+    });
+    
+    // Wait for server to start
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    
+    // Make HTTP request
+    const options = {
+        hostname: 'localhost',
+        port: 8080,
+        path: '/',
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    };
+    
+    return new Promise((resolve, reject) => {
+        const req = http.request(options, (res) => {
+            let data = '';
+            res.on('data', (chunk) => data += chunk);
+            res.on('end', () => {
+                console.log('HTTP Response:', data);
+                resolve(JSON.parse(data));
+            });
+        });
+        
+        req.on('error', reject);
+        req.write(JSON.stringify(testRequest));
+        req.end();
+    });
+}
+
+// Test stdio transport
+async function testStdioTransport() {
+    console.log('Testing stdio transport...');
+    
+    return new Promise((resolve, reject) => {
+        const serverProcess = spawn('node', [path.join(__dirname, '../src/index.js')], {
+            env: { ...process.env, MCP_TRANSPORT: 'stdio' },
+            stdio: ['pipe', 'pipe', 'pipe']
+        });
+        
+        let output = '';
+        let isServerReady = false;
+        
+        serverProcess.stdout.on('data', (data) => {
+            output += data.toString();
+            // Try to parse each line as we receive it
+            const lines = output.split('\n');
+            for (const line of lines) {
+                if (line.trim()) {
+                    try {
+                        const response = JSON.parse(line);
+                        serverProcess.kill();
+                        resolve(response);
+                        return;
+                    } catch (e) {
+                        // Not a complete JSON response, continue collecting
+                    }
+                }
+            }
+        });
+        
+        serverProcess.stderr.on('data', (data) => {
+            const message = data.toString();
+            console.error('Server Error:', message);
+            if (message.includes('MCP Server running in stdio mode')) {
+                isServerReady = true;
+                // Send test request once server is ready
+                serverProcess.stdin.write(JSON.stringify(testRequest) + '\n');
+            }
+        });
+        
+        serverProcess.on('error', reject);
+        
+        // Set a longer timeout as fallback
+        setTimeout(() => {
+            serverProcess.kill();
+            reject(new Error('Stdio transport test timed out after 5 seconds'));
+        }, 5000);
+    });
+}
+
+// Run tests
+async function runTests() {
+    try {
+        // Test HTTP transport
+        const httpResult = await testHttpTransport();
+        console.log('HTTP transport test:', httpResult.result ? 'PASSED' : 'FAILED');
+        
+        // Wait a bit before testing stdio
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        
+        // Test stdio transport
+        const stdioResult = await testStdioTransport();
+        console.log('stdio transport test:', stdioResult.result ? 'PASSED' : 'FAILED');
+        
+    } catch (error) {
+        console.error('Test failed:', error);
+    }
+    
+    // Exit after tests
+    process.exit(0);
+}
+
+// Run the tests
+runTests(); 

--- a/NANO_MCP_SERVER/tests/wallets.json
+++ b/NANO_MCP_SERVER/tests/wallets.json
@@ -1,0 +1,10 @@
+{
+    "wallet2":  {
+                    "privateKey":  "a4a3d0cd01cff28628e2bd187bdb6d39b42779cbc6ffe5ac5685ea58d4b16ae1",
+                    "address":  "nano_1ee6716of16rhrjdxu1ap561c1c5yuey97pewss5kpodytomrqhy9k8h46nz"
+                },
+    "wallet1":  {
+                    "privateKey":  "00b6dbc92e3f7a5a217645b9f257d2071838132fad786b3fddd5cb3a64cdd1f2",
+                    "address":  "nano_3eadyjzpjfocpigqauajzhe1y41z939rhbjdmbed5zxs75hzqswpojus3b3f"
+                }
+}

--- a/NANO_MCP_SERVER/utils/nano-transactions.d.ts
+++ b/NANO_MCP_SERVER/utils/nano-transactions.d.ts
@@ -1,0 +1,24 @@
+import { ConfigValidationResult } from '../types/config';
+import { AccountInfo, Block, PendingBlocks } from '../types/nano';
+export declare class NanoTransactions {
+    private apiUrl;
+    private rpcKey;
+    private gpuKey;
+    private defaultRepresentative;
+    private config;
+    constructor(customConfig?: Partial<{
+        apiUrl: string;
+        rpcKey: string;
+        gpuKey: string;
+        defaultRepresentative: string;
+    }>, config?: any);
+    private rpcCall;
+    validateConfig(errors: string[]): Promise<ConfigValidationResult>;
+    generateWork(hash: string): Promise<string>;
+    getAccountInfo(account: string): Promise<AccountInfo>;
+    getPendingBlocks(account: string): Promise<PendingBlocks>;
+    createOpenBlock(address: string, privateKey: string, sourceBlock: string, sourceAmount: string): Promise<Block>;
+    createSendBlock(fromAddress: string, privateKey: string, toAddress: string, amount: string, accountInfo: AccountInfo): Promise<Block>;
+    receiveAllPending(address: string, privateKey: string): Promise<Block[]>;
+    private makeRequest;
+}

--- a/NANO_MCP_SERVER/utils/nano-transactions.js
+++ b/NANO_MCP_SERVER/utils/nano-transactions.js
@@ -1,0 +1,392 @@
+// WARNING: This file is locked and should not be modified in the future.
+// Any changes to this file may affect the compatibility of nano-mcp.
+// Please refer to the documentation for any updates or modifications.
+
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.NanoTransactions = void 0;
+const node_fetch_1 = __importDefault(require("node-fetch"));
+const nanocurrency_web_1 = require("nanocurrency-web");
+const nanocurrency = require('nanocurrency');
+const { block } = require('nanocurrency-web');
+class NanoTransactions {
+    /**
+     * Constructs a NanoTransactions instance with custom and global configuration.
+     * @param {Object} customConfig - Custom configuration for this instance.
+     * @param {Object} config - Optional global configuration object.
+     */
+    constructor(customConfig, config) {
+        const globalConfig = config?.getNanoConfig() || {};
+        this.apiUrl = customConfig?.apiUrl || globalConfig.rpcUrl || 'https://rpc.nano.to';
+        this.rpcKey = customConfig?.rpcKey || globalConfig.rpcKey || 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23';
+        this.gpuKey = customConfig?.gpuKey || globalConfig.gpuKey;
+        this.defaultRepresentative = customConfig?.defaultRepresentative || globalConfig.defaultRepresentative || 'nano_3qya5xpjfsbk3ndfebo9dsrj6iy6f6idmogqtn1mtzdtwnxu6rw3dz18i6xf';
+        this.config = config;
+        if (config) {
+            const errors = config.validateConfig();
+            if (errors.length > 0) {
+                throw new Error(`Configuration errors: ${errors.join(', ')}`);
+            }
+        }
+    }
+    /**
+     * Makes a generic RPC call to the configured Nano node.
+     * @param {string} action - The RPC action to perform.
+     * @param {Object} params - Additional parameters for the RPC call.
+     * @returns {Promise<Object>} - The response from the Nano node.
+     */
+    async rpcCall(action, params = {}) {
+        console.log('Making RPC call:', { action, ...params });
+        const response = await (0, node_fetch_1.default)(this.apiUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                action,
+                ...params,
+                key: this.rpcKey
+            })
+        });
+        if (!response.ok) {
+            throw new Error(`RPC call failed: ${response.statusText}`);
+        }
+        const data = await response.json();
+        console.log('RPC Response:', data);
+        return data;
+    }
+    /**
+     * Validates the provided configuration and throws if errors are found.
+     * @param {Array<string>} errors - List of configuration errors.
+     * @returns {Promise<Object>} - Validation result object.
+     */
+    async validateConfig(errors) {
+        if (errors?.length > 0) {
+            throw new Error(`Configuration errors: ${errors.join(', ')}`);
+        }
+        return { isValid: true, errors: [], warnings: [] };
+    }
+    /**
+     * Retrieves account information for a given Nano account.
+     * @param {string} account - The Nano account address.
+     * @returns {Promise<Object>} - Account information from the node.
+     */
+    async getAccountInfo(account) {
+        const info = await this.rpcCall('account_info', { account });
+        return info;
+    }
+    /**
+     * Retrieves pending (unreceived) blocks for a given Nano account.
+     * @param {string} account - The Nano account address.
+     * @returns {Promise<Object>} - Pending blocks information.
+     */
+    async getPendingBlocks(account) {
+        const pending = await this.rpcCall('pending', { 
+            account,
+            count: '1',
+            source: 'true'
+        });
+        return pending;
+    }
+    /**
+     * Generates proof-of-work for a given hash, with difficulty based on block type.
+     * @param {string} hash - The hash to generate work for.
+     * @param {boolean} isOpen - Whether this is for an open block (lower difficulty).
+     * @returns {Promise<string>} - The generated work value.
+     */
+    async generateWork(hash, isOpen = false) {
+        if (!hash) {
+            throw new Error('Hash is required for work generation');
+        }
+        console.log('Generating work for hash:', hash);
+        const workResult = await this.rpcCall('work_generate', {
+            hash,
+            key: this.rpcKey,
+            difficulty: isOpen ? 'fffffe0000000000' : 'fffffff800000000' // Use lower difficulty for receive blocks
+        });
+        if (!workResult.work) {
+            throw new Error('Failed to generate work');
+        }
+        return workResult.work;
+    }
+    /**
+     * Creates and processes a receive (or open) block for a pending transaction.
+     * Handles both new and existing accounts, calculates the correct new balance, and submits the block.
+     * @param {string} account - The Nano account address.
+     * @param {string} privateKey - The private key for signing the block.
+     * @param {string} pendingBlock - The hash of the pending block to receive.
+     * @param {string|number|BigInt} pendingAmount - The amount to receive (in raw).
+     * @param {Object|null} accountInfo - Optional account info; if null, treated as a new account.
+     * @returns {Promise<Object>} - The result of the process RPC call.
+     */
+    async createReceiveBlock(account, privateKey, pendingBlock, pendingAmount, accountInfo = null) {
+        try {
+            // For first receive (opening account), use the account's public key
+            // For subsequent receives, use the account's frontier
+            let workHash;
+            if (accountInfo && !accountInfo.error) {
+                workHash = accountInfo.frontier;
+                console.log('Using frontier as work hash:', workHash);
+            } else {
+                // For new accounts, we need to use the account's public key
+                console.log('Account for public key derivation:', account);
+                workHash = nanocurrency_web_1.tools.addressToPublicKey(account);
+                console.log('Derived public key from address:', workHash);
+            }
+            
+            if (!workHash) {
+                throw new Error('Failed to determine work hash');
+            }
+            
+            console.log('Using work hash:', workHash);
+
+            // Generate work with appropriate difficulty
+            const work = await this.rpcCall('work_generate', {
+                hash: workHash,
+                difficulty: !accountInfo || accountInfo.error ? 'fffffe0000000000' : 'fffffff800000000' // Lower difficulty for open blocks
+            });
+
+            if (!work.work) {
+                throw new Error('Failed to generate work');
+            }
+
+            // Ensure account is in nano_ format
+            const nanoAccount = account.replace('xrb_', 'nano_');
+            
+            // Get the representative
+            let representative = this.defaultRepresentative;
+            if (accountInfo && !accountInfo.error && accountInfo.representative) {
+                representative = accountInfo.representative;
+            }
+            console.log('Using representative:', representative);
+
+            // Calculate new balance
+            let newBalance;
+            if (accountInfo && !accountInfo.error) {
+                // For existing accounts, add pending amount to current balance
+                newBalance = (BigInt(accountInfo.balance) + BigInt(pendingAmount)).toString();
+            } else {
+                // For new accounts, balance is just the pending amount
+                newBalance = pendingAmount;
+            }
+            console.log('New balance:', newBalance);
+
+            // Prepare block data for block.receive
+            const receiveBlockData = {
+                walletBalanceRaw: accountInfo && !accountInfo.error ? accountInfo.balance : '0',
+                toAddress: nanoAccount,
+                representativeAddress: representative,
+                frontier: accountInfo && !accountInfo.error ? accountInfo.frontier : '0000000000000000000000000000000000000000000000000000000000000000',
+                transactionHash: pendingBlock,
+                amountRaw: pendingAmount,
+                work: work.work
+            };
+
+            console.log('Block data for nanocurrency-web:', receiveBlockData);
+
+            // Sign the block using nanocurrency-web's block.receive
+            const signedBlock = block.receive(receiveBlockData, privateKey);
+            console.log('Signed block:', signedBlock);
+
+            // Process the block using the signed block
+            const processResult = await this.rpcCall('process', {
+                json_block: 'true',
+                subtype: accountInfo && !accountInfo.error ? 'receive' : 'open',
+                block: signedBlock
+            });
+
+            if (processResult.error) {
+                throw new Error(`Failed to process block: ${processResult.error}`);
+            }
+
+            return processResult;
+        } catch (error) {
+            console.error('Error in createReceiveBlock:', error);
+            throw error;
+        }
+    }
+    /**
+     * Receives all pending blocks for a given account, processing each one sequentially.
+     * @param {string} address - The Nano account address.
+     * @param {string} privateKey - The private key for signing receive blocks.
+     * @returns {Promise<Array<Object>>} - Results of processing each pending block.
+     */
+    async receiveAllPending(address, privateKey) {
+        // Get account info
+        let accountInfo;
+        try {
+            accountInfo = await this.getAccountInfo(address);
+        } catch (error) {
+            // Account not opened yet, which is fine
+            accountInfo = null;
+        }
+
+        // Get pending blocks
+        const pending = await this.getPendingBlocks(address);
+        
+        const results = [];
+        if (pending.blocks && Object.keys(pending.blocks).length > 0) {
+            for (const [hash, blockInfo] of Object.entries(pending.blocks)) {
+                try {
+                    // Convert raw amount to nano for display
+                    const rawToNanoResult = await this.rpcCall('raw_to_nano', {
+                        amount: blockInfo.amount
+                    });
+                    console.log(`Receiving ${rawToNanoResult.nano} NANO from block ${hash}`);
+
+                    const result = await this.createReceiveBlock(
+                        address,
+                        privateKey,
+                        hash,
+                        blockInfo.amount,
+                        accountInfo
+                    );
+                    results.push(result);
+                    
+                    // Update accountInfo for next iteration if the block was processed
+                    if (result.hash) {
+                        try {
+                            accountInfo = await this.getAccountInfo(address);
+                        } catch (error) {
+                            console.error('Failed to update account info:', error);
+                        }
+                    }
+                } catch (error) {
+                    console.error('Failed to process pending block:', error);
+                    results.push({ error: error.message });
+                }
+            }
+        }
+        return results;
+    }
+    /**
+     * Generates a new Nano wallet (seed, account, private/public key).
+     * @returns {Promise<Object>} - The generated wallet information.
+     */
+    async generateWallet() {
+        const walletData = nanocurrency_web_1.wallet.generateLegacy();
+        return {
+            address: walletData.accounts[0].address,
+            privateKey: walletData.accounts[0].privateKey,
+            publicKey: walletData.accounts[0].publicKey,
+            seed: walletData.seed
+        };
+    }
+    /**
+     * Makes a generic RPC request to the Nano node.
+     * @param {string} method - The RPC method/action.
+     * @param {Object} params - Parameters for the RPC call.
+     * @returns {Promise<Object>} - The response from the Nano node.
+     */
+    async makeRequest(method, params) {
+        return this.rpcCall(method, params);
+    }
+    /**
+     * Sends a transaction from one Nano account to another.
+     * Handles work generation, block signing, and submission.
+     * @param {string} fromAddress - The sender's Nano account address.
+     * @param {string} privateKey - The sender's private key.
+     * @param {string} toAddress - The recipient's Nano account address.
+     * @param {string|number|BigInt} amountRaw - The amount to send (in raw).
+     * @returns {Promise<Object>} - Success status and block hash or error message.
+     */
+    async sendTransaction(fromAddress, privateKey, toAddress, amountRaw) {
+        try {
+            const formattedFromAddress = fromAddress.replace('xrb_', 'nano_');
+            const formattedToAddress = toAddress.replace('xrb_', 'nano_');
+            // Ensure amountRaw is a string
+            const amountRawString = amountRaw.toString();
+
+            // Get account info for current balance and frontier
+            const accountInfo = await this.makeRequest('account_info', {
+                account: formattedFromAddress,
+                representative: true,
+                json_block: 'true'
+            });
+            
+            if (accountInfo.error) {
+                if (accountInfo.error === 'Account not found') {
+                    throw new Error('Account has no previous blocks. Please make sure it has received some NANO first.');
+                }
+                throw new Error(accountInfo.error);
+            }
+
+            console.log('Account info:', accountInfo);
+
+            // Calculate new balance after sending
+            const currentBalance = BigInt(accountInfo.balance);
+            const sendAmount = BigInt(amountRawString);
+            const newBalance = (currentBalance - sendAmount).toString();
+
+            console.log('Current balance:', currentBalance.toString());
+            console.log('Send amount:', sendAmount.toString());
+            console.log('New balance after send:', newBalance);
+
+            // Generate work
+            const workData = await this.makeRequest('work_generate', {
+                hash: accountInfo.frontier,
+                difficulty: 'fffffff800000000'  // Higher difficulty for send blocks
+            });
+
+            if (!workData || !workData.work) {
+                throw new Error('Failed to generate work');
+            }
+
+            // Get the representative
+            let representative = this.defaultRepresentative;
+            if (accountInfo && accountInfo.representative) {
+                representative = accountInfo.representative;
+            }
+            console.log('Using representative:', representative);
+
+            // Prepare block data
+            const blockData = {
+                walletBalanceRaw: newBalance,
+                fromAddress: formattedFromAddress,
+                toAddress: formattedToAddress,
+                representativeAddress: representative,
+                frontier: accountInfo.frontier,
+                amountRaw: amountRawString,
+                work: workData.work
+            };
+
+            console.log('Block data for send:', blockData);
+
+            // Sign the block using nanocurrency-web
+            const signedBlock = nanocurrency_web_1.block.send(blockData, privateKey);
+            console.log('Signed block:', signedBlock);
+
+            // Process the block
+            const processResult = await this.makeRequest('process', {
+                json_block: 'true',
+                subtype: 'send',
+                block: signedBlock
+            });
+
+            if (processResult.error) {
+                throw new Error(processResult.error);
+            }
+
+            return { success: true, hash: processResult.hash };
+        } catch (error) {
+            console.error('Send Transaction Error:', error);
+            return { success: false, error: error.message };
+        }
+    }
+    /**
+     * Retrieves the balance for a given Nano account.
+     * @param {string} account - The Nano account address.
+     * @returns {Promise<Object>} - Balance information from the node.
+     */
+    async getBalance(account) {
+        const balance = await this.rpcCall('account_balance', { account });
+        return {
+            balance: balance.balance,
+            pending: balance.pending
+        };
+    }
+}
+exports.NanoTransactions = NanoTransactions;

--- a/NANO_MCP_SERVER/utils/schema-validator.d.ts
+++ b/NANO_MCP_SERVER/utils/schema-validator.d.ts
@@ -1,0 +1,10 @@
+import { JSONSchema7 } from 'json-schema';
+export declare class SchemaValidator {
+    private static instance;
+    private ajv;
+    private constructor();
+    static getInstance(): SchemaValidator;
+    validate(data: unknown, schema: JSONSchema7): void;
+    addSchema(schema: JSONSchema7, id: string): void;
+    getSchema(id: string): JSONSchema7 | undefined;
+}

--- a/NANO_MCP_SERVER/utils/schema-validator.js
+++ b/NANO_MCP_SERVER/utils/schema-validator.js
@@ -1,0 +1,47 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SchemaValidator = void 0;
+const ajv_1 = __importDefault(require("ajv"));
+class SchemaValidator {
+    constructor() {
+        this.ajv = new ajv_1.default({
+            allErrors: true,
+            verbose: true,
+            strict: false
+        });
+    }
+    static getInstance() {
+        if (!SchemaValidator.instance) {
+            SchemaValidator.instance = new SchemaValidator();
+        }
+        return SchemaValidator.instance;
+    }
+    validate(data, schema) {
+        const validate = this.ajv.compile(schema);
+        const valid = validate(data);
+        if (!valid) {
+            const error = {
+                code: -32602,
+                message: 'Invalid parameters',
+                details: {
+                    errors: validate.errors?.map(err => ({
+                        path: err.instancePath,
+                        message: err.message,
+                        params: err.params
+                    }))
+                }
+            };
+            throw error;
+        }
+    }
+    addSchema(schema, id) {
+        this.ajv.addSchema(schema, id);
+    }
+    getSchema(id) {
+        return this.ajv.getSchema(id)?.schema;
+    }
+}
+exports.SchemaValidator = SchemaValidator;

--- a/NANO_MCP_SERVER/utils/test/package.json
+++ b/NANO_MCP_SERVER/utils/test/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@chainreactionom/nano-mcp-server": "^1.0.10",
+    "nano-mcp": "^1.2.4",
+    "nanocurrency-web": "^1.4.3"
+  }
+}

--- a/NANO_MCP_SERVER/utils/test/test-receive.js
+++ b/NANO_MCP_SERVER/utils/test/test-receive.js
@@ -1,0 +1,202 @@
+const https = require('https');
+const { wallet, tools, block } = require('nanocurrency-web');
+
+// Helper function to make RPC calls
+async function makeRPCCall(action, params) {
+    return new Promise((resolve, reject) => {
+        const data = JSON.stringify({
+            action,
+            ...params,
+            key: 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23'
+        });
+
+        console.log('Making RPC call:', JSON.parse(data));
+
+        const options = {
+            hostname: 'rpc.nano.to',
+            port: 443,
+            path: '/',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': data.length
+            }
+        };
+
+        const req = https.request(options, (res) => {
+            let responseData = '';
+
+            res.on('data', (chunk) => {
+                responseData += chunk;
+            });
+
+            res.on('end', () => {
+                try {
+                    const jsonResponse = JSON.parse(responseData);
+                    console.log('RPC Response:', jsonResponse);
+                    resolve(jsonResponse);
+                } catch (error) {
+                    reject(new Error(`Failed to parse response: ${error.message}`));
+                }
+            });
+        });
+
+        req.on('error', (error) => {
+            reject(error);
+        });
+
+        req.write(data);
+        req.end();
+    });
+}
+
+// Helper function to wait for a specified time
+function wait(minutes) {
+    return new Promise(resolve => setTimeout(resolve, minutes * 60 * 1000));
+}
+
+async function testReceiveScenario() {
+    try {
+        // Step 1: Generate wallet
+        console.log('1. Generating new wallet...');
+        
+        // Generate a new wallet using nanocurrency-web
+        const walletData = wallet.generateLegacy();
+        const account = walletData.accounts[0].address;
+        const privateKey = walletData.accounts[0].privateKey;
+        const publicKey = walletData.accounts[0].publicKey;
+        const seed = walletData.seed;
+        
+        console.log('\nWallet generated successfully!');
+        console.log('Seed (KEEP THIS SAFE):', seed);
+        console.log('Account Address:', account);
+        console.log('Public Key:', publicKey);
+        console.log('Private Key:', privateKey);
+
+        // Step 2: Initialize the account
+        console.log('\n2. Checking account info...');
+        const initResult = await makeRPCCall('account_info', {
+            account: account
+        });
+        
+        if (initResult.error) {
+            console.log('Account not yet initialized (This is normal for new accounts)');
+        } else {
+            console.log('Account info:', initResult);
+        }
+
+        // Step 3: Wait for funds
+        console.log('\n3. Waiting for funds...');
+        console.log(`Please send exactly 0.00001 NANO to this address:\n${account}`);
+        console.log('\nWaiting 4 minutes for funds to arrive...');
+        
+        // Wait for 4 minutes
+        for (let i = 0; i < 4; i++) {
+            await wait(1);
+            console.log(`${3 - i} minutes remaining...`);
+            
+            // Check for pending during wait
+            const checkPending = await makeRPCCall('pending', {
+                account: account,
+                count: '1',
+                source: 'true'
+            });
+            
+            if (checkPending.blocks && Object.keys(checkPending.blocks).length > 0) {
+                console.log('\nPending transaction detected!');
+                break;
+            }
+        }
+
+        // Step 4: Check for pending blocks
+        console.log('\n4. Checking for pending blocks...');
+        const pendingResult = await makeRPCCall('pending', {
+            account: account,
+            count: '1',
+            source: 'true'
+        });
+        console.log('Pending blocks:', pendingResult);
+
+        if (pendingResult.blocks && Object.keys(pendingResult.blocks).length > 0) {
+            // Step 5: Generate work for receiving
+            console.log('\n5. Generating work...');
+            const workResult = await makeRPCCall('work_generate', {
+                hash: publicKey, // For first receive, use public key as frontier
+                key: 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23'
+            });
+            console.log('Work generated:', workResult);
+
+            if (!workResult.work) {
+                throw new Error('Failed to generate work');
+            }
+
+            // Step 6: Process pending blocks
+            console.log('\n6. Processing pending blocks...');
+            for (const [hash, blockInfo] of Object.entries(pendingResult.blocks)) {
+                // Convert raw amount to nano for display
+                const rawToNanoResult = await makeRPCCall('raw_to_nano', {
+                    amount: blockInfo.amount
+                });
+                console.log(`Receiving ${rawToNanoResult.nano} NANO from block ${hash}`);
+
+                // Create and sign the receive block using nanocurrency-web
+                const receiveBlockData = {
+                    walletBalanceRaw: '0', // Initial balance is 0 for first receive
+                    toAddress: account,
+                    representativeAddress: account, // Using self as representative for test
+                    frontier: '0000000000000000000000000000000000000000000000000000000000000000', // Genesis frontier for first receive
+                    transactionHash: hash,
+                    amountRaw: blockInfo.amount,
+                    work: workResult.work
+                };
+
+                // Create and sign the block
+                const signedBlock = block.receive(receiveBlockData, privateKey);
+
+                // Process the signed block
+                const processResult = await makeRPCCall('process', {
+                    json_block: 'true',
+                    subtype: 'receive',
+                    block: signedBlock
+                });
+                console.log('Block processed:', processResult);
+            }
+
+            // Step 7: Final balance check
+            console.log('\n7. Checking final balance...');
+            const balanceResult = await makeRPCCall('account_balance', {
+                account: account
+            });
+            
+            if (balanceResult.balance) {
+                const finalBalanceNano = await makeRPCCall('raw_to_nano', {
+                    amount: balanceResult.balance
+                });
+                console.log('Final balance:', finalBalanceNano.nano, 'NANO');
+            } else {
+                console.log('Final balance:', balanceResult);
+            }
+        } else {
+            console.log('No pending blocks found after waiting');
+        }
+
+    } catch (error) {
+        console.error('\nError occurred during test:');
+        console.error('Message:', error.message);
+        if (error.response) {
+            console.error('RPC Response:', error.response.data);
+        }
+        throw error;
+    }
+}
+
+// Run the test
+console.log('Starting NANO receive test scenario...\n');
+testReceiveScenario()
+    .then(() => {
+        console.log('\nTest completed successfully');
+    })
+    .catch(err => {
+        console.error('\nTest failed with error:', err);
+        process.exit(1);
+    }); 

--- a/NANO_MCP_SERVER/utils/test/test-send.js
+++ b/NANO_MCP_SERVER/utils/test/test-send.js
@@ -1,0 +1,92 @@
+const { NanoTransactions } = require('nano-mcp/dist/utils/nano-transactions');
+
+// Mock config object for testing
+const mockConfig = {
+    getNanoConfig: () => ({
+        rpcUrl: 'https://rpc.nano.to',
+        rpcKey: 'RPC-KEY-BAB822FCCDAE42ECB7A331CCAAAA23',
+        gpuKey: '',
+        defaultRepresentative: 'nano_3arg3asgtigae3xckabaaewkx3bzsh7nwz7jkmjos79ihyaxwphhm6qgjps4'
+    }),
+    validateConfig: () => []
+};
+
+// Helper function to wait and check balance
+async function waitForBalance(nanoTx, address, timeoutSeconds = 120) {
+    console.log(`\nWaiting up to ${timeoutSeconds} seconds for funds...`);
+    const startTime = Date.now();
+    const endTime = startTime + (timeoutSeconds * 1000);
+
+    while (Date.now() < endTime) {
+        const secondsLeft = Math.round((endTime - Date.now()) / 1000);
+        console.log(`${secondsLeft} seconds remaining...`);
+
+        const checkBalance = await nanoTx.makeRequest('account_balance', {
+            account: address
+        });
+
+        // If there are pending funds, receive them
+        if (checkBalance.pending !== '0' || checkBalance.receivable !== '0') {
+            console.log('\nPending funds detected!');
+            return checkBalance;
+        }
+
+        // Wait 10 seconds before next check
+        await new Promise(resolve => setTimeout(resolve, 10000));
+    }
+
+    return null;
+}
+
+async function testSendScenario() {
+    console.log('Starting NANO send test scenario...');
+    
+    // Initialize source wallet
+    const sourceWallet = {
+        seed: '4479c1cd3ba579b541995111459177e5c49765dab19eaa0062cd659b44a2021b',
+        account: 'nano_31f9ptrsorqactjzqep53iixe5kdrbzbkuobz8w1wg7uabzgfhcpxbc4ssgu',
+        privateKey: 'adaf9e5f8d619b4fa92ddefae84adc07a50b79ff158405aa8b77920e649e44cc'
+    };
+    
+    console.log('Source wallet address:', sourceWallet.account);
+    
+    // Generate destination wallet
+    const destinationWallet = await new NanoTransactions({}, mockConfig).generateWallet();
+    console.log('Generated destination wallet:', destinationWallet.address);
+    
+    // Check initial balances
+    console.log('\nChecking initial balances...');
+    const sourceBalance = await new NanoTransactions({}, mockConfig).makeRequest('account_balance', {
+        account: sourceWallet.account
+    });
+    console.log('Source account balance:', sourceBalance);
+    
+    // Send funds to destination
+    console.log('\nSending funds to destination...');
+    const nanoTransactions = new NanoTransactions({}, mockConfig);
+    const sendAmount = '10000000000000000000000000'; // 0.00001 NANO
+    const sendResult = await nanoTransactions.sendTransaction(
+        sourceWallet.account,
+        sourceWallet.privateKey,
+        destinationWallet.address,
+        sendAmount
+    );
+    console.log('Send result:', sendResult);
+    
+    // Check final balances
+    console.log('\nChecking final balances...');
+    const finalSourceBalance = await nanoTransactions.makeRequest('account_balance', {
+        account: sourceWallet.account
+    });
+    const finalDestBalance = await nanoTransactions.makeRequest('account_balance', {
+        account: destinationWallet.address
+    });
+    
+    console.log('Final source balance:', finalSourceBalance);
+    console.log('Final destination balance:', finalDestBalance);
+    
+    console.log('\nTest completed.');
+}
+
+// Run the test
+testSendScenario().catch(console.error); 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Agentic Fund Management
+
+This repository contains three main components:
+
+- **NANO_MCP_SERVER** – original Nano MCP server codebase
+- **nano-mcp-api** – REST API wrapper used for this demo
+- **fund-demo** – simple multi-agent demonstration that generates a wallet and writes the address to `fund-wallet.txt`
+
+## Setup
+
+Install dependencies and run tests in each project:
+
+```bash
+cd NANO_MCP_SERVER && npm install --omit=dev && cd ..
+cd nano-mcp-api && npm install && npm test && cd ..
+cd fund-demo && npm install && npm test && cd ..
+```
+
+## Running the demo
+
+1. Start the REST API:
+   ```bash
+   node nano-mcp-api/src/server.js
+   ```
+2. In another terminal, run the demo:
+   ```bash
+   cd fund-demo && npm start
+   ```
+
+The generated wallet address is stored in `fund-demo/fund-wallet.txt`.

--- a/fund-demo/README.md
+++ b/fund-demo/README.md
@@ -1,0 +1,27 @@
+# Agentic Fund Management Demo
+
+This demo shows a simplified multi-agent framework for managing a cryptocurrency fund. It uses the Nano MCP REST API to generate a wallet and demonstrates how specialized agents could collaborate.
+
+## Running the Demo
+
+First start the REST API:
+
+```bash
+node ../nano-mcp-api/src/server.js &
+```
+
+Then run the demo script:
+
+```bash
+npm start
+```
+
+The fund wallet address is written to `fund-wallet.txt` for testing so you can fund it later.
+
+## Tests
+
+Run automated tests with:
+
+```bash
+npm test
+```

--- a/fund-demo/index.js
+++ b/fund-demo/index.js
@@ -1,0 +1,106 @@
+const axios = require('axios');
+const fs = require('fs');
+
+const API_URL = 'http://localhost:3000';
+const WALLET_FILE = 'fund-wallet.txt';
+
+class ResearchAgent {
+  async evaluate() {
+    console.log('ResearchAgent: evaluating assets...');
+    // demo placeholder
+    return [{ symbol: 'NANO', score: 0.9 }];
+  }
+}
+
+class MarketAnalysisAgent {
+  async analyze() {
+    console.log('MarketAnalysisAgent: analyzing market...');
+    // demo placeholder
+    return { trend: 'neutral' };
+  }
+}
+
+class PortfolioManagementAgent {
+  constructor(riskAgent) {
+    this.riskAgent = riskAgent;
+    this.portfolio = [];
+  }
+
+  decide(research, market) {
+    console.log('PortfolioManagementAgent: making decisions...');
+    // simple demo: if top asset has score > 0.5 buy small amount
+    if (research[0].score > 0.5) {
+      const decision = { action: 'buy', asset: research[0].symbol, amount: 1 };
+      if (this.riskAgent.check(decision)) {
+        this.portfolio.push(decision);
+        return decision;
+      }
+    }
+    return null;
+  }
+}
+
+class RiskManagementAgent {
+  check(decision) {
+    console.log('RiskManagementAgent: approving decision');
+    return true; // always approve in demo
+  }
+}
+
+class TradingAgent {
+  async execute(decision, wallet) {
+    console.log('TradingAgent: executing trade', decision);
+    // demo: just log
+  }
+}
+
+class SecurityAgent {
+  async storeWallet(wallet) {
+    fs.writeFileSync(WALLET_FILE, wallet.address);
+    console.log(`SecurityAgent: wallet address saved to ${WALLET_FILE}`);
+  }
+}
+
+class ComplianceAgent {
+  report() {
+    console.log('ComplianceAgent: generating report...');
+  }
+}
+
+async function initializeWallet() {
+  const res = await axios.get(`${API_URL}/generateWallet`);
+  return res.data;
+}
+
+async function main() {
+  const research = new ResearchAgent();
+  const market = new MarketAnalysisAgent();
+  const risk = new RiskManagementAgent();
+  const portfolio = new PortfolioManagementAgent(risk);
+  const trading = new TradingAgent();
+  const security = new SecurityAgent();
+  const compliance = new ComplianceAgent();
+
+  console.log('Initializing fund wallet...');
+  const wallet = await initializeWallet();
+  await security.storeWallet(wallet);
+
+  const researchData = await research.evaluate();
+  const marketOutlook = await market.analyze();
+  const decision = portfolio.decide(researchData, marketOutlook);
+  if (decision) {
+    await trading.execute(decision, wallet);
+  }
+
+  compliance.report();
+  console.log('Demo complete');
+}
+
+module.exports = { main };
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/fund-demo/package-lock.json
+++ b/fund-demo/package-lock.json
@@ -1,0 +1,1424 @@
+{
+  "name": "fund-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fund-demo",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.10.0",
+        "chai": "^5.2.0",
+        "mocha": "^11.7.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "license": "ISC"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
+      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
+      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.2.tgz",
+      "integrity": "sha512-Xz4Nm9c+LiBHhDR5bDLnNzmj6+5F+cyEAWPMkbs2awq/dYazR/efelZzUAjB/y3kNHL+uzkHvxVVpaOfGCPV7A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/fund-demo/package.json
+++ b/fund-demo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "fund-demo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "axios": "^1.10.0",
+    "chai": "^5.2.0",
+    "mocha": "^11.7.0"
+  }
+}

--- a/fund-demo/test/demo.test.js
+++ b/fund-demo/test/demo.test.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+
+let server;
+
+before(function(done){
+  // start the API server
+  const apiPath = path.join(__dirname, '..', '..', 'nano-mcp-api', 'src', 'server.js');
+  server = require(apiPath);
+  setTimeout(done, 500);
+});
+
+after(function(){
+  server.close && server.close();
+});
+
+describe('Agentic Fund Demo', function(){
+  it('should generate wallet file', async function(){
+    const { main } = require('../index.js');
+    await main();
+    await new Promise(resolve => setTimeout(resolve, 500)); // allow async ops
+    const walletFile = path.join(__dirname, '..', 'fund-wallet.txt');
+    const exists = fs.existsSync(walletFile);
+    expect(exists).to.equal(true);
+    const addr = fs.readFileSync(walletFile, 'utf8');
+    expect(addr).to.match(/^nano_/);
+  });
+});

--- a/nano-mcp-api/README.md
+++ b/nano-mcp-api/README.md
@@ -1,0 +1,42 @@
+# Nano MCP REST API
+
+This project wraps the [NANO MCP Server](https://github.com/dhyabi2/NANO_MCP_SERVER) and exposes a simple REST interface.
+
+## Installation
+
+```
+npm install
+```
+
+## Usage
+
+Run the server:
+
+```
+node src/server.js
+```
+
+The API listens on `http://localhost:3000` by default.
+
+### Endpoints
+
+- `GET /initialize` – server capabilities
+- `GET /generateWallet` – generate a new wallet
+- `GET /balance/:address` – get balance
+- `GET /account/:address` – get account info
+- `GET /pending/:address` – get pending blocks
+- `POST /initializeAccount` – body: `{ address, privateKey }`
+- `POST /sendTransaction` – body: `{ fromAddress, toAddress, amountRaw, privateKey }`
+- `POST /receiveAllPending` – body: `{ address, privateKey }`
+- `POST /ai/ask` – body: `{ prompt }` – returns a Gemini AI response
+
+## Testing
+
+```
+npm test
+```
+
+### AI configuration
+
+Set `GEMINI_API_KEY` environment variable to override the default sample key used
+for the `/ai/ask` endpoint.

--- a/nano-mcp-api/package-lock.json
+++ b/nano-mcp-api/package-lock.json
@@ -1,0 +1,2341 @@
+{
+  "name": "nano-mcp-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nano-mcp-api",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "body-parser": "^2.2.0",
+        "express": "^5.1.0",
+        "nano-mcp": "file:../NANO_MCP_SERVER"
+      },
+      "devDependencies": {
+        "chai": "^5.2.0",
+        "mocha": "^11.7.0",
+        "supertest": "^7.1.1"
+      }
+    },
+    "../NANO_MCP_SERVER": {
+      "name": "nano-mcp",
+      "version": "1.2.28",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "body-parser": "^2.2.0",
+        "express": "^5.1.0",
+        "nanocurrency": "^1.12.0",
+        "nanocurrency-web": "^1.4.3",
+        "node-fetch": "^2.7.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
+      },
+      "bin": {
+        "nano-mcp": "src/index.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
+      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
+      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nano-mcp": {
+      "resolved": "../NANO_MCP_SERVER",
+      "link": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
+      "integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.1.tgz",
+      "integrity": "sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.2.tgz",
+      "integrity": "sha512-Xz4Nm9c+LiBHhDR5bDLnNzmj6+5F+cyEAWPMkbs2awq/dYazR/efelZzUAjB/y3kNHL+uzkHvxVVpaOfGCPV7A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/nano-mcp-api/package.json
+++ b/nano-mcp-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "nano-mcp-api",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "body-parser": "^2.2.0",
+    "express": "^5.1.0",
+    "nano-mcp": "file:../NANO_MCP_SERVER"
+  },
+  "devDependencies": {
+    "chai": "^5.2.0",
+    "mocha": "^11.7.0",
+    "supertest": "^7.1.1"
+  }
+}

--- a/nano-mcp-api/src/server.js
+++ b/nano-mcp-api/src/server.js
@@ -1,0 +1,125 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const { NanoMCPServer } = require('nano-mcp/src/server');
+const { execFile } = require('child_process');
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || 'AIzaSyBNZQBYpPqen_tDAIuZ7aRdHaj4fgR_19c';
+
+// create underlying Nano MCP server instance
+const nanoServer = new NanoMCPServer();
+
+const app = express();
+app.use(bodyParser.json());
+
+// helper to call json-rpc method
+async function call(method, params = {}) {
+  const request = { jsonrpc: '2.0', method, params, id: Date.now() };
+  const resp = await nanoServer.handleRequest(request);
+  if (resp.error) {
+    throw new Error(resp.error.message);
+  }
+  return resp.result;
+}
+
+app.get('/initialize', async (req, res) => {
+  try {
+    const result = await call('initialize');
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/generateWallet', async (req, res) => {
+  try {
+    const result = await call('generateWallet');
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/balance/:address', async (req, res) => {
+  try {
+    const result = await call('getBalance', { address: req.params.address });
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/account/:address', async (req, res) => {
+  try {
+    const result = await call('getAccountInfo', { address: req.params.address });
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/pending/:address', async (req, res) => {
+  try {
+    const result = await call('getPendingBlocks', { address: req.params.address });
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/initializeAccount', async (req, res) => {
+  try {
+    const { address, privateKey } = req.body;
+    const result = await call('initializeAccount', { address, privateKey });
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/sendTransaction', async (req, res) => {
+  try {
+    const { fromAddress, toAddress, amountRaw, privateKey } = req.body;
+    const result = await call('sendTransaction', { fromAddress, toAddress, amountRaw, privateKey });
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/receiveAllPending', async (req, res) => {
+  try {
+    const { address, privateKey } = req.body;
+    const result = await call('receiveAllPending', { address, privateKey });
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// simple AI endpoint using Google Gemini
+app.post('/ai/ask', async (req, res) => {
+  try {
+    const { prompt } = req.body;
+    const url = `https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent?key=${GEMINI_API_KEY}`;
+    const payload = JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] });
+    execFile('curl', ['-s', '-X', 'POST', url, '-H', 'Content-Type: application/json', '-d', payload], (err, stdout) => {
+      if (err) return res.status(500).json({ error: err.message });
+      try {
+        const data = JSON.parse(stdout);
+        const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+        res.json({ text });
+      } catch (e) {
+        res.status(500).json({ error: e.message });
+      }
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+const server = app.listen(PORT, () => {
+  console.log(`Nano MCP REST API running on port ${PORT}`);
+});
+
+module.exports = server;

--- a/nano-mcp-api/test/server.test.js
+++ b/nano-mcp-api/test/server.test.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai');
+const request = require('supertest');
+const path = require('path');
+
+let server;
+
+before(function(done){
+  const apiPath = path.join(__dirname, '..', 'src', 'server.js');
+  server = require(apiPath);
+  // server.js exports nothing but starts listening; wait a bit
+  setTimeout(done, 500);
+});
+
+after(function(){
+  server.close && server.close();
+});
+
+describe('Nano MCP REST API', function(){
+  it('should return capabilities', async function(){
+    const res = await request('http://localhost:3000').get('/initialize');
+    expect(res.status).to.equal(200);
+    expect(res.body.capabilities).to.be.an('object');
+  });
+
+  it('should generate wallet', async function(){
+    const res = await request('http://localhost:3000').get('/generateWallet');
+    expect(res.status).to.equal(200);
+    expect(res.body.address).to.be.a('string');
+    expect(res.body.privateKey).to.be.a('string');
+  });
+
+  it('should return AI response', async function(){
+    const res = await request('http://localhost:3000')
+      .post('/ai/ask')
+      .send({ prompt: 'Hello' });
+    expect(res.status).to.equal(200);
+    expect(res.body.text).to.be.a('string');
+  });
+});

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,0 @@
-pending


### PR DESCRIPTION
## Summary
- add README describing repo structure and demo usage
- implement simplified multi-agent demo that persists a wallet address
- ignore generated wallet file
- provide mocha test for demo

## Testing
- `npm install --omit=dev` in `NANO_MCP_SERVER`
- `npm install` and `npm test` in `nano-mcp-api`
- `npm install` and `npm test` in `fund-demo`


------
https://chatgpt.com/codex/tasks/task_e_68554b17a924832783b5be97a3066062